### PR TITLE
ignore __pycache__ folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info
 build/
+__pycache__


### PR DESCRIPTION
Just getting started with my dev environment - would like to ignore `__pycache__` folders created locally.