### PR TITLE
use self-hosted GHA runners

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,8 +3,10 @@ name: Python package
 on: [push]
 
 jobs:
-  build:
+  use-hosted-runners:
+    runs-on: self-hosted-eks
 
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,13 +1,9 @@
 name: Python package
-
 on: [push]
 
 jobs:
-  use-hosted-runners:
-    runs-on: self-hosted-eks
-
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-eks
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
This should make the runners faster, more secure, cheaper, etc.

Taken from [instructions here](https://anaconda.atlassian.net/wiki/spaces/AD/pages/2809135111/Anaconda-Distribution+Self-Hosted+Runners).