### PR TITLE
pin_*(name) --> name x

### DIFF
--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -209,8 +209,8 @@ def render(
             "ppcle64": selector_dict.get("ppcle64", "0") == "1",
             "cran_mirror": "https://cloud.r-project.org",
             "compiler": expand_compiler,
-            "pin_compatible": lambda x, max_pin=None, min_pin=None, lower_bound=None, upper_bound=None: f"{x}",  # noqa: E501
-            "pin_subpackage": lambda x, max_pin=None, min_pin=None, exact=False: f"{x}",
+            "pin_compatible": lambda x, max_pin=None, min_pin=None, lower_bound=None, upper_bound=None: f"{x} x",  # noqa: E501
+            "pin_subpackage": lambda x, max_pin=None, min_pin=None, exact=False: f"{x} x",
             "cdt": lambda x: f"{x}-cos6-x86_64",
             "os.environ.get": lambda name, default="": "",
             "ccache": lambda name, method="": "ccache",

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -210,7 +210,7 @@ def render(
             "cran_mirror": "https://cloud.r-project.org",
             "compiler": expand_compiler,
             "pin_compatible": lambda x, max_pin=None, min_pin=None, lower_bound=None, upper_bound=None: f"{x} x",  # noqa: E501
-            "pin_subpackage": lambda x, max_pin=None, min_pin=None, exact=False: f"{x} x",
+            "pin_subpackage": lambda x, max_pin=None, min_pin=None, exact=False: f"{x} x",  # noqa: E501
             "cdt": lambda x: f"{x}-cos6-x86_64",
             "os.environ.get": lambda name, default="": "",
             "ccache": lambda name, method="": "ccache",


### PR DESCRIPTION
Changes:
- when calling pin_compatible or pin_subpackage, set x as version.

Example: pin_compatible('numpy') becomes numpy x