### PR TITLE
Adds `py.typed` file and configures `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 namespaces = false
+where = ["percy"]
+
+[tool.setuptools.package-data]
+"percy" = ["py.typed"]
 
 [project]
 name = "percy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 namespaces = false
-where = ["percy"]
 
 [tool.setuptools.package-data]
 "percy" = ["py.typed"]


### PR DESCRIPTION
UNTESTED
- I don't think we really can test these changes until we deploy another version of percy(?). I've also never done this before, and am soley basing these changes off of some stackoverflow posts
- The intent is, in theory, these changes _should_ allow us to use `mypy` (or other Python static analyzers) to leverage the type-hints provided in this project
- This came out of trying to use `percy` in the `perseverance_scripts` project. Here are some docs on the matter:
  - https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker
  - https://peps.python.org/pep-0561/