### PR TITLE
Adds missing dependencies

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -2,6 +2,9 @@ name: percy
 
 dependencies:
   - python
+  - pytest
+  - pytest-cov
+  - pip
   - click
   - conda
   - jinja2


### PR DESCRIPTION
- Adds `pip`, `pytest`, and `pytest-cov` to the project
- I noticed these were missing as I attempted my first dev setup of `percy`.
  - `pip` is required for the `pip install -e .` README step
  - There's a `make` directive for `pytest`
  - I added `pytest-cov` for good measure/future needs