### PR TITLE
Fixes JSON schema limits

### DIFF
--- a/percy/render/recipe.py
+++ b/percy/render/recipe.py
@@ -62,7 +62,10 @@ class Recipe:
                 "op": {"enum": ["add", "replace", "remove"]},
                 "path": {"type": "string"},
                 "match": {"type": "string"},
-                "value": {"type": ["string", "array"], "items": {"type": "string"}},
+                "value": {
+                    "type": ["string", "integer", "boolean", "array"],
+                    "items": {"type": "string"}
+                },
                 "description": {"type": "string"},
             },
             "required": [


### PR DESCRIPTION
Fixes #35 
- Tested with `conda develop` on `perseverance-scripts`
- I briefly scanned some recipe examples and I did not see any case of
  - Floating point numbers
  - Arrays consisting of integers or bools

So for now, I think this is a decent schema to go with that should cover most, if not all, recipes