### PR TITLE
Support inserting into an array with the "add" operation

### DIFF
--- a/percy/render/recipe.py
+++ b/percy/render/recipe.py
@@ -677,6 +677,8 @@ class Recipe:
 
         # infer data type
         in_list = False
+        add_insert = False
+        add_insert_index = 0
         raw_value = self.get(path, "NOPE")
         if op == "remove":
             if raw_value == "NOPE":
@@ -746,6 +748,23 @@ class Recipe:
                     return
             else:
                 # path found - store value to add
+                try:
+                    # Check to see if the path ends with /<n>.
+                    # This means that we need to insert the given value at the given index.
+                    # See https://www.rfc-editor.org/rfc/rfc6902.html#section-4.1
+                    add_insert_index = int(parent_name)
+                    add_insert = True
+
+                    # Get the actual raw value of the array.
+                    raw_value = self.get(parent_path, "NOPE")
+
+                    path = parent_path
+                    parent_path, parent_name = parent_path.split("/", 1)
+
+                    expanded_match = re.compile("NOPE")
+                except ValueError:
+                    pass
+
                 if isinstance(raw_value, str):
                     if re.search(match, raw_value):
                         path = parent_path
@@ -782,6 +801,11 @@ class Recipe:
             new_range.pop(i)
             insert_index = i
             index_set = True
+
+        if add_insert:
+            index_set = True
+            insert_index = add_insert_index
+
         range = new_range
         if not index_set:
             for i, e in reversed(list(enumerate(range))):


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6902/#section-4.1 says:
> The "add" operation performs one of the following functions, depending upon what the target location references:
>
> * If the target location specifies an array index, a new value is inserted into the array at the specified index.
>* If the target location specifies an object member that does not already exist, a new member is added to the object.
>* If the target location specifies an object member that does exist, that member's value is replaced.

Our `add` operation only supports the last two points.

This PR implements the first point, which is that if the path (target location) specifies an index (for example `source/patches/0`), then a new value will be inserted at the specified index.