### PR TITLE
Initial integration with `percy aggregate` command and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,140 @@
 # Percy
 
-  This library is able to render recipes for all variants (subdir, python... combination).
-  When given a directory of feedstocks (aggregate), it can produce a rough build order.
-  It can be used as a command line tool but is mostly intended to be used as a library.
+## Table of Contents
+<!-- TOC -->
 
-  Why not using conda build to render?
-  conda build resolves dependencies to qualify versions and process run_exports and other keys.
-  This library renders without querying a channel, and is more suited for development phase.
+- [Percy](#percy)
+    - [Table of Contents](#table-of-contents)
+    - [Overview](#overview)
+- [Getting Started](#getting-started)
+    - [General Installation](#general-installation)
+        - [Install into your current environment](#install-into-your-current-environment)
+        - [Install into a custom percy environment](#install-into-a-custom-percy-environment)
+- [Developer Installation](#developer-installation)
+        - [Running pre-commit checks](#running-pre-commit-checks)
+    - [Command line examples](#command-line-examples)
+    - [Other examples](#other-examples)
+        - [Recipe patching](#recipe-patching)
+        - [Python 3.11 buildout](#python-311-buildout)
+        - [Build order examples](#build-order-examples)
+        - [Test install examples](#test-install-examples)
+        - [Find pinning issues in aggregate](#find-pinning-issues-in-aggregate)
+
+<!-- /TOC -->
+## Overview
+
+This library is able to render recipes for all variants (subdir, python... combination).
+When given a directory of feedstocks (aggregate), it can produce a rough build order.
+It can be used as a command line tool but is mostly intended to be used as a library.
+
+Why not using conda build to render?
+conda build resolves dependencies to qualify versions and process run_exports and other keys.
+This library renders without querying a channel, and is more suited for development phase.
+
+# Getting Started
+
+## General Installation
+
+### Install into your current environment
+```sh
+make install
+```
+
+### Install into a custom percy environment
+```sh
+make environment
+conda activate percy
+```
+
+# Developer Installation
+```sh
+make dev
+conda activate percy
+```
+The `dev` recipe will configure a `conda` environment named `percy` with
+development tools installed.
+
+`pre-commit` is automatically installed and configured for you to run a number
+of automated checks on each commit.
+
+**NOTE:** As of writing, only a handful of files are checked by the linter and
+`pre-commit`. **ANY NEW FILES** should be added to these checks.
+
+### Running pre-commit checks
+The provided `Makefile` also provides a handful of convenience recipes for
+running all or part of the `pre-commit` automations:
+1. `make test`: Runs all the unit tests
+1. `make test-cov`: Reports the current test coverage percentage and indicates
+   which lines are currently untested.
+1. `make lint`: Runs our `pylint` configuration, based on Google's Python
+   standards.
+1. `make format`: Automatically formats code
+1. `make analyze`: Runs the static analyzer, `mypy`.
+1. `make pre-commit`: Runs all the `pre-commit` checks
+
+## Command line examples
+
+From within a feedstock:
+
+  percy recipe --help
+
+- Render the recipe
+
+        percy recipe render --help
+        percy recipe render -s linux-64 -p 3.10 -k blas_impl openblas
+
+- Identify if the feedstock is pinned to the latest, compared to defautls:
+
+        percy recipe outdated --help
+        percy recipe outdated
+
+From within aggregate:
+
+Queries can be performed on feedstock names (-f), package names (-pkg) and group names (-g).
+A group name corresponds to the github/gitlab... organization name, extracted from dev_url.
+
+  percy aggregate --help
+
+- When updating a package pinned in cbc, show rebuild order:
+
+        percy aggregate downstream --help
+        percy aggregate downstream -f libxml2-feedstock
+
+- When working on a group of packages, show build order:
+
+        percy aggregate order --help
+        percy aggregate order -f dask-feedstock -f dask-core-feedstock -f distributed-feedstock
+        percy aggregate order -g dask
+
+- When building from scratch, show what to build based on leaf packages:
+
+        percy aggregate upstream --help
+        percy aggregate upstream -f pytorch-feedstock
+
+- Identify which feedstocks are not pinned to the latest, compared to defautls:
+
+        percy aggregate outdated --help
+        percy aggregate outdated
+
+## Other examples
+
+### Recipe patching
+
+See percy/examples/patch
+
+### Python 3.11 buildout
+
+See percy/examples/py311 [here](percy/examples/py311/README.md)
+
+### Build order examples
+
+See percy/examples/blts
+
+### Test install examples
+
+  pytest -n auto --junit-xml="test_install.xml" --html="test_install.html" --self-contained-html ./percy/examples/preinstall/test_install.py --feedstock=./gensim-feedstock
 
 
-  ## Installation
+### Find pinning issues in aggregate
 
-    conda create -n percy -c cbouss/label/percy percy
-
-  ## Installation for development
-
-    conda env create -f environment.yaml --name percy
-    conda activate percy
-    pip install -e .
-
-  ## Command line examples
-
-  From within a feedstock:
-
-    percy recipe --help
-
-  - Render the recipe
-
-          percy recipe render --help
-          percy recipe render -s linux-64 -p 3.10 -k blas_impl openblas
-
-  - Identify if the feedstock is pinned to the latest, compared to defautls:
-
-          percy recipe outdated --help
-          percy recipe outdated
-
-  From within aggregate:
-
-  Queries can be performed on feedstock names (-f), package names (-pkg) and group names (-g).
-  A group name corresponds to the github/gitlab... organization name, extracted from dev_url.
-
-    percy aggregate --help
-
-  - When updating a package pinned in cbc, show rebuild order:
-
-          percy aggregate downstream --help
-          percy aggregate downstream -f libxml2-feedstock
-
-  - When working on a group of packages, show build order:
-
-          percy aggregate order --help
-          percy aggregate order -f dask-feedstock -f dask-core-feedstock -f distributed-feedstock
-          percy aggregate order -g dask
-
-  - When building from scratch, show what to build based on leaf packages:
-
-          percy aggregate upstream --help
-          percy aggregate upstream -f pytorch-feedstock
-
-  - Identify which feedstocks are not pinned to the latest, compared to defautls:
-
-          percy aggregate outdated --help
-          percy aggregate outdated
-
-  ## Other examples
-
-  ### Recipe patching
-
-  See percy/examples/patch
-
-  ### Python 3.11 buildout
-
-  See percy/examples/py311 [here](percy/examples/py311/README.md)
-
-  ### Build order examples
-
-  See percy/examples/blts
-
-  ### Test install examples
-
-    pytest -n auto --junit-xml="test_install.xml" --html="test_install.html" --self-contained-html ./percy/examples/preinstall/test_install.py --feedstock=./gensim-feedstock
-
-
-  ### Find pinning issues in aggregate
-
-    python ./percy/examples/aggregate_deps_issue_finder/aggregate_deps_issue_finder.py
+  python ./percy/examples/aggregate_deps_issue_finder/aggregate_deps_issue_finder.py

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ name: percy
 dependencies:
   - black
   - isort
-  - conda-forge::mypy
+  - mypy
   - python>=3.8
   - pytest
   - pytest-cov

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -261,7 +261,7 @@ def render(
                 variants=selector_dict,
             )
             return rendered[0][0].meta
-        elif renderer_type == RendererType.PARSE_TREE:
+        elif renderer_type == RendererType.PERCY:
             parser = RecipeParser(meta_yaml)
             return parser.render_to_object()
         else:

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, List, Optional
 from enum import Enum
 
-from percy.percy.render.recipe_parser import RecipeParser
+from percy.render.recipe_parser import RecipeParser
 
 try:
     from ruamel.yaml import YAML
@@ -165,7 +165,7 @@ def render(
     recipe_dir: Path | str,
     meta_yaml: str,
     selector_dict: dict[str, Any],
-    renderer_type: Optional(RendererType) = None,
+    renderer_type: Optional[RendererType] = None,
 ) -> dict[str, Any]:
     """
     Convert recipe text into data structure
@@ -262,7 +262,6 @@ def render(
             )
             return rendered[0][0].meta
         elif renderer_type == RendererType.PARSE_TREE:
-            # TODO complete
             parser = RecipeParser(meta_yaml)
             return parser.render_to_object()
         else:

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -32,7 +32,7 @@ class RendererType(Enum):
     PYYAML = 1
     RUAMEL = 2
     CONDA = 3
-    PARSE_TREE = 4  # Custom renderer, found in `recipe_parser.py`
+    PERCY = 4  # Custom parse-tree-based renderer, found in `recipe_parser.py`
 
 
 if has_ruamel:

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -12,7 +12,7 @@ import subprocess
 from pathlib import Path
 import logging
 import configparser
-from typing import Any
+from typing import Any, Optional
 from multiprocessing import Pool
 
 from percy.render.recipe import render, Package, RendererType
@@ -172,9 +172,9 @@ class Feedstock:
     weight: int
 
 
-def _render(feedstock_repo, recipe_path, subdir, python, others):
+def _render(feedstock_repo, recipe_path, subdir, python, others, renderer):
     try:
-        rendered_recipes = render(recipe_path, subdir, python, others)
+        rendered_recipes = render(recipe_path, subdir, python, others, renderer=renderer)
     except Exception as exc:
         logging.error(f"Render issue {feedstock_repo.name} : {exc}")
         rendered_recipes = []
@@ -267,7 +267,8 @@ class Aggregate:
         self,
         subdir: str = "linux-64",
         python: str = "3.10",
-        others: dict[str, Any] = None,
+        others: Optional[dict[str, Any]] = None,
+        renderer: Optional[RendererType] = None,
     ) -> dict[str, Package]:
         """Load aggregate feedstocks.
 
@@ -330,7 +331,7 @@ class Aggregate:
                 continue
 
             # add to render list
-            to_render.append((feedstock_repo, recipe_path, subdir, python, others))
+            to_render.append((feedstock_repo, recipe_path, subdir, python, others, renderer))
 
         # render recipes
         with Pool() as pool:

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -15,7 +15,7 @@ import configparser
 from typing import Any
 from multiprocessing import Pool
 
-from percy.render.recipe import render, Package
+from percy.render.recipe import render, Package, RendererType
 
 
 class PackageNode:

--- a/percy/render/recipe.py
+++ b/percy/render/recipe.py
@@ -11,7 +11,7 @@ import re
 import itertools
 import logging
 from copy import deepcopy
-from typing import Any, Dict, List, Set, TextIO
+from typing import Any, Dict, List, Optional, Set, TextIO
 from pathlib import Path
 from dataclasses import dataclass, field
 from urllib.parse import urlparse
@@ -76,9 +76,9 @@ class Recipe:
     def __init__(
         self,
         recipe_file: Path,
-        variant_id: str = None,
-        variant: Variant = None,
-        renderer: RendererType = None,
+        variant_id: Optional(str) = None,
+        variant: Optional(Variant) = None,
+        renderer: Optional(RendererType) = None,
     ):
         """Constructor
 
@@ -249,7 +249,7 @@ class Recipe:
         """
         return self.meta_yaml != self.orig.meta_yaml
 
-    def dump(self):
+    def dump(self) -> str:
         """Dump recipe content"""
         return "\n".join(self.meta_yaml) + "\n"
 

--- a/percy/render/recipe.py
+++ b/percy/render/recipe.py
@@ -76,9 +76,9 @@ class Recipe:
     def __init__(
         self,
         recipe_file: Path,
-        variant_id: Optional(str) = None,
-        variant: Optional(Variant) = None,
-        renderer: Optional(RendererType) = None,
+        variant_id: Optional[str] = None,
+        variant: Optional[Variant] = None,
+        renderer: Optional[RendererType] = None,
     ):
         """Constructor
 

--- a/percy/render/recipe_parser.py
+++ b/percy/render/recipe_parser.py
@@ -240,7 +240,7 @@ class _Node:
             value = "Comment node"
         return (
             f"Node: {value}\n"
-            f"  - Comment:      {self.comment}\n"
+            f"  - Comment:      {self.comment!r}\n"
             f"  - Child count:  {len(self.children)}\n"
             f"  - List?:        {self.list_member_flag}\n"
             f"  - Multiline?:   {self.multiline_flag}\n"

--- a/percy/render/recipe_parser.py
+++ b/percy/render/recipe_parser.py
@@ -235,8 +235,11 @@ class _Node:
         Renders the Node as a string. Useful for debugging purposes.
         :return: The node's value, as a string
         """
+        value = self.value
+        if self.is_comment():
+            value = "Comment node"
         return (
-            f"Node: {self.value}\n"
+            f"Node: {value}\n"
             f"  - Comment:      {self.comment}\n"
             f"  - Child count:  {len(self.children)}\n"
             f"  - List?:        {self.list_member_flag}\n"

--- a/percy/render/recipe_parser.py
+++ b/percy/render/recipe_parser.py
@@ -888,6 +888,11 @@ class RecipeParser:
                 if not child.multiline_flag
                 else "\n".join(child.value)
             )
+            # TODO if enabled, string replace `{{}}` in `value`
+            # TODO handle `| lower` and similar
+            # TODO create new function for handling grammar
+            if enable_variables:
+                pass
 
             if child.list_member_flag:
                 if key not in data:

--- a/percy/render/recipe_parser.py
+++ b/percy/render/recipe_parser.py
@@ -927,13 +927,13 @@ class RecipeParser:
 
     @staticmethod
     def _render_object_tree(
-        node: _Node, enable_variables: bool, data: JsonType
+        node: _Node, replace_variables: bool, data: JsonType
     ) -> None:
         """
         Recursive helper function that traverses the parse tree to generate
         a Pythonic data object.
         :param node:                Current node in the tree
-        :param enable_variables:    If set to True, this replaces all variables
+        :param replace_variables:   If set to True, this replaces all variable
                                     substitutions with their set values.
         :param data:                Accumulated data structure
         """
@@ -956,7 +956,7 @@ class RecipeParser:
             # TODO if enabled, string replace `{{}}` in `value`
             # TODO handle `| lower` and similar
             # TODO create new function for handling grammar
-            if enable_variables:
+            if replace_variables:
                 pass
 
             # Empty keys are interpreted to point to `None`
@@ -978,13 +978,15 @@ class RecipeParser:
 
             # All other keys prep for containing more dictionaries
             data.setdefault(key, {})
-            RecipeParser._render_object_tree(child, enable_variables, data[key])
+            RecipeParser._render_object_tree(
+                child, replace_variables, data[key]
+            )
 
-    def render_to_object(self, enable_variables: bool = False) -> JsonType:
+    def render_to_object(self, replace_variables: bool = False) -> JsonType:
         """
         Takes the underlying state of the parse tree and produces a Pythonic
         object/dictionary representation. Analogous to `json.load()`.
-        :param enable_variables:    (Optional) If set to True, this replaces
+        :param replace_variables:   (Optional) If set to True, this replaces
                                     all variable substitutions with their set
                                     values.
         :return: Pythonic data object representation of the recipe.
@@ -994,7 +996,7 @@ class RecipeParser:
         # Bootstrap/flatten the root-level
         for child in self._root.children:
             data.setdefault(child.value, {})
-            RecipeParser._render_object_tree(child, enable_variables, data)
+            RecipeParser._render_object_tree(child, replace_variables, data)
 
         return data
 

--- a/percy/tests/test_aux_files/multi-output.yaml
+++ b/percy/tests/test_aux_files/multi-output.yaml
@@ -1,0 +1,23 @@
+outputs:
+  - name: libdb
+    build:
+      run_exports:
+        # OK for minor
+        # https://abi-laboratory.pro/?view=timeline&l=libdb
+        - bar
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libdb${SHLIB_EXT}  # [unix]
+        - if not exist %LIBRARY_BIN%\libdb%SHLIB_EXT%  # [win]
+  # metapackage for old anaconda name (only available on linux/mac)
+  - name: db
+    requirements:
+      build:
+        # compilers are to ensure that variants are captured
+        - foo3
+        - foo2
+      run:
+        - foo
+    test:
+      commands:
+        - db_archive -m hello

--- a/percy/tests/test_aux_files/simple-recipe.yaml
+++ b/percy/tests/test_aux_files/simple-recipe.yaml
@@ -11,11 +11,14 @@ build:
   is_true: true
 
 requirements:
+  empty_field1:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix]
+  empty_field2:
   run:
     - python
+  empty_field3:
 
 about:
   summary: This is a small recipe for testing

--- a/percy/tests/test_aux_files/simple-recipe.yaml
+++ b/percy/tests/test_aux_files/simple-recipe.yaml
@@ -28,6 +28,7 @@ about:
 multi_level:
   list_1:
     - foo
+    # Ensure a comment in a list is supported
     - bar
   list_2:
     - cat

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
@@ -11,11 +11,14 @@ build:
   is_true: false
 
 requirements:
+  empty_field1:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix]
+  empty_field2:
   run:
     - cpython
+  empty_field3:
 
 about:
   summary:

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
@@ -31,6 +31,7 @@ about:
 multi_level:
   list_1:
     - foo
+    # Ensure a comment in a list is supported
     - bar
   list_2:
     - cat

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -114,7 +114,13 @@ def test_render_to_object() -> None:
         },
         "build": {"is_true": True, "skip": True, "number": 0},
         "package": {"name": "{{ name|lower }}"},
-        "requirements": {"host": ["setuptools", "fakereq"], "run": ["python"]},
+        "requirements": {
+            "empty_field1": None,
+            "host": ["setuptools", "fakereq"],
+            "empty_field2": None,
+            "run": ["python"],
+            "empty_field3": None,
+        },
         "multi_level": {
             "list_3": ["ls", "sl", "cowsay"],
             "list_2": ["cat", "bat", "mat"],

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -91,6 +91,38 @@ def test_dog_food_medium() -> None:
     assert parser.render() == simple
 
 
+def test_render_to_object() -> None:
+    """
+    Tests rendering a recipe to an object format.
+    """
+    parser = load_recipe("simple-recipe.yaml")
+    assert parser.render_to_object() == {
+        "about": {
+            "description": SIMPLE_DESCRIPTION,
+            "license": "Apache-2.0 AND MIT",
+            "summary": "This is a small recipe for testing",
+        },
+        "test_var_usage": {
+            "foo": "{{ version }}",
+            "bar": [
+                "baz",
+                "{{ zz_non_alpha_first }}",
+                "blah",
+                "This {{ name }} is silly",
+                "last",
+            ],
+        },
+        "build": {"is_true": True, "skip": True, "number": 0},
+        "package": {"name": "{{ name|lower }}"},
+        "requirements": {"host": ["setuptools", "fakereq"], "run": ["python"]},
+        "multi_level": {
+            "list_3": ["ls", "sl", "cowsay"],
+            "list_2": ["cat", "bat", "mat"],
+            "list_1": ["foo", "bar"],
+        },
+    }
+
+
 ## Values ##
 
 


### PR DESCRIPTION
This PR adds a new flag to the `percy aggregate` commands that allows the user to pick a parser implementation.

The "parse tree" we've been working on is publicly known as the "percy parser" and can be run like:
```sh
percy aggregate order --renderer percy
```
By default, `PYYAML` is used, as was done prior to this work.

Also contains:
- A handful of recipe parsing bug fixes, with associated unit test improvements
- Readme updates, including a Table of Contents and updated developer instructions
- Small type annotation additions