### PR TITLE
Enforcing Automatic Code formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ lint:			## runs the linter against the project
 	pylint --rcfile=.pylintrc $(LINTER_FILES)
 
 format:			## runs the code auto-formatter
-	isort --profile black --line-length=80 $(LINTER_FILES) percy/tests/
-	black --line-length=80 $(LINTER_FILES) percy/tests/
+	isort --profile black --line-length=80 percy
+	black --line-length=80 percy
 
 analyze:		## runs static analyzer on the project
 	mypy --config-file=.mypy.ini $(LINTER_FILES)

--- a/percy/commands/aggregate.py
+++ b/percy/commands/aggregate.py
@@ -1,13 +1,15 @@
-from pathlib import Path
-import click
+import functools
 import os
 import sys
-import functools
-import yaml
 from itertools import groupby
+from pathlib import Path
+
+import click
+import yaml
+
 import percy.render.aggregate
-import percy.repodata.repodata
 import percy.render.recipe
+import percy.repodata.repodata
 
 
 def get_configured_aggregate(cmd_line=None):
@@ -33,7 +35,9 @@ def get_configured_aggregate(cmd_line=None):
     return cwd
 
 
-def load_aggregate(obj, subdir, python, others, renderer: percy.render.recipe.RendererType):
+def load_aggregate(
+    obj, subdir, python, others, renderer: percy.render.recipe.RendererType
+):
     print(f"Renderer in use: {renderer.name}")
     aggregate_path = obj["aggregate_directory"]
     aggregate_repo = percy.render.aggregate.Aggregate(aggregate_path)
@@ -47,12 +51,20 @@ def load_aggregate(obj, subdir, python, others, renderer: percy.render.recipe.Re
 
 
 def print_build_order(buildout):
-    stages = [list(result) for key, result in groupby(buildout, key=lambda f: f.weight)]
+    stages = [
+        list(result)
+        for key, result in groupby(buildout, key=lambda f: f.weight)
+    ]
     for i, stage in enumerate(stages):
         for feedstock in stage:
-            print(f"{i:03} {feedstock.name:30} {list(feedstock.packages.keys())}")
+            print(
+                f"{i:03} {feedstock.name:30} {list(feedstock.packages.keys())}"
+            )
 
-def sanitize_renderer_enum(_0, _1, value: str) -> percy.render.recipe.RendererType:
+
+def sanitize_renderer_enum(
+    _0, _1, value: str
+) -> percy.render.recipe.RendererType:
     """
     Takes the renderer type as a user provided string and converts it to the
     enum form.
@@ -61,6 +73,7 @@ def sanitize_renderer_enum(_0, _1, value: str) -> percy.render.recipe.RendererTy
     """
     # Access should be safe as `click` handles the input limitations for us.
     return percy.render.recipe.RendererType[value.upper()]
+
 
 def base_options(f):
     @click.option(
@@ -148,7 +161,10 @@ def order_options(f):
 
 @click.group(short_help="Commands for operating on aggregates.")
 @click.option(
-    "--aggregate", "-a", metavar="DIRECTORY", help="Aggregate directory to operate on."
+    "--aggregate",
+    "-a",
+    metavar="DIRECTORY",
+    help="Aggregate directory to operate on.",
 )
 @click.pass_context
 def aggregate(ctx, aggregate):
@@ -210,13 +226,15 @@ def downstream(
     )
 
     # print build order
-    order = " ".join([
-        f"groups:{groups}",
-        f"feedstocks:{feedstocks}",
-        f"packages:{packages}",
-        f"allow_list:{allow_list}",
-        f"block_list:{block_list}",
-    ])
+    order = " ".join(
+        [
+            f"groups:{groups}",
+            f"feedstocks:{feedstocks}",
+            f"packages:{packages}",
+            f"allow_list:{allow_list}",
+            f"block_list:{block_list}",
+        ]
+    )
     print(f"\n\nDownstream build order ({order}):")
     print_build_order(buildout)
 
@@ -225,7 +243,17 @@ def downstream(
 @click.pass_obj
 @base_options
 @order_options
-def upstream(obj, subdir, python, others, renderer, groups, feedstocks, packages, drop_noarch):
+def upstream(
+    obj,
+    subdir,
+    python,
+    others,
+    renderer,
+    groups,
+    feedstocks,
+    packages,
+    drop_noarch,
+):
     """Prints build order of feedstock upstream dependencies"""
 
     # load aggregate
@@ -237,12 +265,14 @@ def upstream(obj, subdir, python, others, renderer, groups, feedstocks, packages
     )
 
     # print build order
-    order = " ".join([
-        f"groups:{groups}",
-        f"feedstocks:{feedstocks}",
-        f"packages:{packages}",
-        f"drop_noarch:{drop_noarch}",
-    ])
+    order = " ".join(
+        [
+            f"groups:{groups}",
+            f"feedstocks:{feedstocks}",
+            f"packages:{packages}",
+            f"drop_noarch:{drop_noarch}",
+        ]
+    )
     print(f"\n\nUpstream build order ({order}):")
     print_build_order(buildout)
 
@@ -251,7 +281,17 @@ def upstream(obj, subdir, python, others, renderer, groups, feedstocks, packages
 @click.pass_obj
 @base_options
 @order_options
-def order(obj, subdir, python, others, renderer, groups, feedstocks, packages, drop_noarch):
+def order(
+    obj,
+    subdir,
+    python,
+    others,
+    renderer,
+    groups,
+    feedstocks,
+    packages,
+    drop_noarch,
+):
     """Prints build order of specified feedstocks"""
 
     # load aggregate
@@ -265,12 +305,14 @@ def order(obj, subdir, python, others, renderer, groups, feedstocks, packages, d
     )
 
     # print build order
-    order = " ".join([
-        f"groups:{groups}",
-        f"feedstocks:{feedstocks}",
-        f"packages:{packages}",
-        f"drop_noarch:{drop_noarch}",
-    ])
+    order = " ".join(
+        [
+            f"groups:{groups}",
+            f"feedstocks:{feedstocks}",
+            f"packages:{packages}",
+            f"drop_noarch:{drop_noarch}",
+        ]
+    )
     print(f"\n\nBuild order ({order})):")
     print_build_order(buildout)
 
@@ -296,7 +338,9 @@ def order(obj, subdir, python, others, renderer, groups, feedstocks, packages, d
     multiple=False,
     help="Identify packages from aggregate not on defaults",
 )
-def outdated(obj, subdir, python, others, renderer, missing_local, missing_defaults):
+def outdated(
+    obj, subdir, python, others, renderer, missing_local, missing_defaults
+):
     """Prints outdated with defaults"""
 
     results = {}
@@ -305,7 +349,9 @@ def outdated(obj, subdir, python, others, renderer, missing_local, missing_defau
     aggregate_repo = load_aggregate(obj, subdir, python, others, renderer)
 
     # load defaults
-    defaults_pkgs = percy.repodata.repodata.get_latest_package_list(subdir, True)
+    defaults_pkgs = percy.repodata.repodata.get_latest_package_list(
+        subdir, True
+    )
 
     # compare aggregate with defaults
     for local_name, package in aggregate_repo.packages.items():
@@ -323,7 +369,9 @@ def outdated(obj, subdir, python, others, renderer, missing_local, missing_defau
                 "local_version": None,
                 "local_build_number": None,
                 "defaults_version": defaults_pkgs[name]["version"],
-                "defaults_build_number": int(defaults_pkgs[name]["build_number"]),
+                "defaults_build_number": int(
+                    defaults_pkgs[name]["build_number"]
+                ),
             }
 
     # find missing from defaults

--- a/percy/commands/main.py
+++ b/percy/commands/main.py
@@ -1,6 +1,7 @@
 import click
-from percy.commands.recipe import recipe
+
 from percy.commands.aggregate import aggregate
+from percy.commands.recipe import recipe
 
 
 # root click group

--- a/percy/commands/recipe.py
+++ b/percy/commands/recipe.py
@@ -1,10 +1,12 @@
 # ruff: noqa: E501
 
-from pathlib import Path
-import click
-import os
 import functools
 import json
+import os
+from pathlib import Path
+
+import click
+
 import percy.render.recipe
 
 
@@ -70,7 +72,9 @@ def base_options(f):
 
 
 @click.group(short_help="Commands for operating on a recipe.")
-@click.option("--recipe", "-r", metavar="FILE", help="Recipe meta.yaml to operate on.")
+@click.option(
+    "--recipe", "-r", metavar="FILE", help="Recipe meta.yaml to operate on."
+)
 @click.pass_context
 def recipe(ctx, recipe):
     """Commands that operate on a recipe."""
@@ -118,7 +122,9 @@ def outdated(obj, subdir, python, others, backend):
 
     # load defaults
     print(f"Checking outdated for subdir { subdir[0] }")
-    defaults_pkgs = percy.repodata.repodata.get_latest_package_list(subdir[0], True)
+    defaults_pkgs = percy.repodata.repodata.get_latest_package_list(
+        subdir[0], True
+    )
 
     # compare package with defaults
     for recipe in render_results:
@@ -146,7 +152,9 @@ def outdated(obj, subdir, python, others, backend):
     help="Increment build number",
 )
 @click.argument("patch_file", metavar="FILE")
-def patch(obj, subdir, python, others, backend, increment_build_number, patch_file):
+def patch(
+    obj, subdir, python, others, backend, increment_build_number, patch_file
+):
     """Patch a recipe. Takes a patch file as input, with content like:
 
     \b

--- a/percy/examples/blts/gen_blts_build_order.py
+++ b/percy/examples/blts/gen_blts_build_order.py
@@ -1,15 +1,15 @@
 """ Generate build scripts to build all packages depending on python.
 """
 
-import percy.render.aggregate as aggregate
-from itertools import groupby
 import os
+from itertools import groupby
+
 import yaml
 
-def gen_blts_build_order(
-    aggregate_path, subdir, python_ref, packages
-):
+import percy.render.aggregate as aggregate
 
+
+def gen_blts_build_order(aggregate_path, subdir, python_ref, packages):
     os.makedirs(f"./{subdir}/", exist_ok=True)
 
     # load aggregate
@@ -31,9 +31,10 @@ def gen_blts_build_order(
 
     # write stage build order
     stages = [
-        list(result) for key, result in groupby(blts_buildout, key=lambda f: f.weight)
+        list(result)
+        for key, result in groupby(blts_buildout, key=lambda f: f.weight)
     ]
-    build_order = { "python" : python_ref, "stages" : {} }
+    build_order = {"python": python_ref, "stages": {}}
     for i, stage in enumerate(stages):
         stage_id = f"{i:03}"
         build_order["stages"][stage_id] = []
@@ -42,8 +43,8 @@ def gen_blts_build_order(
     with open(f"./{subdir}/blts_{subdir}_build_order.yaml", "w") as f:
         yaml.dump(build_order, f)
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     gen_blts_build_order(
         "/Users/cbousseau/work/recipes/aggregate/",
         "linux-64",
@@ -58,7 +59,7 @@ if __name__ == "__main__":
             "scipy",
             "conda",
             "conda-build",
-        ]
+        ],
     )
 
     gen_blts_build_order(
@@ -75,5 +76,5 @@ if __name__ == "__main__":
             "scipy",
             "conda",
             "conda-build",
-        ]
+        ],
     )

--- a/percy/examples/build_order_to_jira.py
+++ b/percy/examples/build_order_to_jira.py
@@ -2,16 +2,18 @@
     Create corresponding tickets in Jira.
 """
 
-import percy.render.aggregate as aggregate
 import argparse
-from pathlib import Path
-import requests
-import json
 import itertools
+import json
 import logging
 import os
+from pathlib import Path
+
+import requests
 from jira.client import JIRA
 from jira.exceptions import JIRAError
+
+import percy.render.aggregate as aggregate
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -35,7 +37,9 @@ def add_issue(login, token, dry_run, current_epic_key, target_pkg, pkg):
             "https://anaconda.atlassian.net/", basic_auth=(login, token)
         )
         allfields = perseverance_jira.fields()
-        perseverance_fields_map = {field["name"]: field["id"] for field in allfields}
+        perseverance_fields_map = {
+            field["name"]: field["id"] for field in allfields
+        }
 
     logging.info(f"NEW {pkg}")
 
@@ -169,7 +173,9 @@ class JiraSync:
             epic_tasks.extend(
                 [
                     getattr(
-                        issue.fields, self.perseverance_fields_map["Package Name"], ""
+                        issue.fields,
+                        self.perseverance_fields_map["Package Name"],
+                        "",
                     ).lower()
                     for issue in issues
                 ]
@@ -191,9 +197,13 @@ class JiraSync:
                         "summary": desc,
                         "description": desc,
                         "issuetype": {"name": "Task"},
-                        self.perseverance_fields_map["Package Name"]: package_name,
+                        self.perseverance_fields_map[
+                            "Package Name"
+                        ]: package_name,
                     }
-                    issue_fields[self.perseverance_fields_map["Epic Link"]] = epic_key
+                    issue_fields[
+                        self.perseverance_fields_map["Epic Link"]
+                    ] = epic_key
                     try:
                         # create issue
                         if not self.dry_run:
@@ -218,7 +228,9 @@ def print_build_order(buildout):
     ]
     for i, stage in enumerate(stages):
         for feedstock in stage:
-            print(f"{i:03} {feedstock.name:30} {list(feedstock.packages.keys())}")
+            print(
+                f"{i:03} {feedstock.name:30} {list(feedstock.packages.keys())}"
+            )
 
 
 if __name__ == "__main__":
@@ -274,7 +286,9 @@ if __name__ == "__main__":
     for i, stage in enumerate(stages):
         for feedstock in stage:
             all_packages.update(set(feedstock.packages.keys()))
-            print(f"{i:03} {feedstock.name:30} {list(feedstock.packages.keys())}")
+            print(
+                f"{i:03} {feedstock.name:30} {list(feedstock.packages.keys())}"
+            )
     for pkg in main_pkgs.difference(all_packages):
         print(f"Missing from build order: {pkg}")
 

--- a/percy/examples/patch/updater.py
+++ b/percy/examples/patch/updater.py
@@ -1,11 +1,12 @@
 """ Update a recipe
 """
 
-import percy.render.recipe as recipe
 import argparse
-from pathlib import Path
-import logging
 import json
+import logging
+from pathlib import Path
+
+import percy.render.recipe as recipe
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -39,7 +40,12 @@ def create_parser() -> argparse.ArgumentParser:
 def load_recipe(recipe_path):
     others = {"r_implementation": "r-base"}
     rendered_recipes = recipe.render(
-        recipe_path, ["linux-64"], ["3.10"], others, False, recipe.RendererType.RUAMEL
+        recipe_path,
+        ["linux-64"],
+        ["3.10"],
+        others,
+        False,
+        recipe.RendererType.RUAMEL,
     )
     rendered_recipe = next(iter(rendered_recipes))
     return rendered_recipe

--- a/percy/examples/patch/updater_standalone.py
+++ b/percy/examples/patch/updater_standalone.py
@@ -3,12 +3,13 @@
 """
 
 import argparse
-from pathlib import Path
-import logging
-import re
 import copy
 import json
+import logging
+import re
+from pathlib import Path
 from typing import Any
+
 from ruamel.yaml import YAML
 
 yaml = YAML(typ="jinja2")
@@ -38,7 +39,9 @@ class Recipe:
             self.meta = yaml.load(fp)
             self.packages = {}
             if not self.meta.get("outputs", []):
-                name = self.meta.get("package", {}).get("name", "unknown").strip()
+                name = (
+                    self.meta.get("package", {}).get("name", "unknown").strip()
+                )
                 self.packages[name] = ""
             else:
                 outputs = self.meta.get("outputs", [])
@@ -185,7 +188,9 @@ class Recipe:
                 # apply package specific operation for all packages
                 for package_path in self.packages.values():
                     opcopy = copy.deepcopy(op)
-                    opcopy["path"] = opcopy["path"].replace("@output/", package_path)
+                    opcopy["path"] = opcopy["path"].replace(
+                        "@output/", package_path
+                    )
                     self._patch(opcopy)
                     self.save()
                     self.reload()
@@ -239,14 +244,18 @@ class Recipe:
                 # finding range of direct parent
                 # (not doing the leg work of going up the tree if parent is not found)
                 try:
-                    (start_row, start_col, end_row, _) = self.get_raw_range(parent_path)
+                    (start_row, start_col, end_row, _) = self.get_raw_range(
+                        parent_path
+                    )
                 except KeyError:
                     logging.warning(f"Path not found while applying op:{opop}")
                 else:
                     # adding value to end of parent
                     # if value is a list, adding as a list to parent
                     # if value is a string, adding as parent: value
-                    parent_range = copy.deepcopy(self.meta_yaml[start_row:end_row])
+                    parent_range = copy.deepcopy(
+                        self.meta_yaml[start_row:end_row]
+                    )
                     parent_insert_index = 0
                     for i, e in reversed(list(enumerate(parent_range))):
                         if e.strip():
@@ -254,11 +263,13 @@ class Recipe:
                             break
                     if isinstance(value, list):
                         parent_range.insert(
-                            parent_insert_index, " " * start_col + f"{parent_name}:"
+                            parent_insert_index,
+                            " " * start_col + f"{parent_name}:",
                         )
                         for val in value:
                             parent_range.insert(
-                                parent_insert_index + 1, " " * start_col + f"  - {val}"
+                                parent_insert_index + 1,
+                                " " * start_col + f"  - {val}",
                             )
                     else:
                         parent_range.insert(
@@ -318,19 +329,22 @@ class Recipe:
             for new_val in value:
                 for i, m in match_lines.items():
                     to_insert.add(
-                        m.string.replace(m.groupdict()["pattern"], new_val).replace(
-                            "#", "  #", 1
-                        )
+                        m.string.replace(
+                            m.groupdict()["pattern"], new_val
+                        ).replace("#", "  #", 1)
                     )
             if not to_insert:
                 to_insert = set(value)
             for new_val in to_insert:
                 if in_list:
                     range.insert(
-                        insert_index, " " * start_col + f"- {new_val.strip(' -')}"
+                        insert_index,
+                        " " * start_col + f"- {new_val.strip(' -')}",
                     )
                 else:
-                    range.insert(insert_index, " " * start_col + f"{new_val.strip()}")
+                    range.insert(
+                        insert_index, " " * start_col + f"{new_val.strip()}"
+                    )
 
         # apply change
         self.meta_yaml[start_row:end_row] = range

--- a/percy/examples/preinstall/conftest.py
+++ b/percy/examples/preinstall/conftest.py
@@ -1,20 +1,21 @@
 _DEFAULT_AGGREGATE = "~/work/recipes/aggregate/"
-_DEFAULT_PYTHON = ['3.8', '3.9', '3.10', '3.11']
+_DEFAULT_PYTHON = ["3.8", "3.9", "3.10", "3.11"]
 _DEFAULT_SUBDIRS = [
-    'linux-64',
-    'linux-ppc64le',
-    'linux-aarch64',
-    'osx-64',
-    'osx-arm64',
-    'win-64',
-    'linux-s390x',
+    "linux-64",
+    "linux-ppc64le",
+    "linux-aarch64",
+    "osx-64",
+    "osx-arm64",
+    "win-64",
+    "linux-s390x",
 ]
+
 
 def pytest_addoption(parser):
     parser.addoption("--feedstock", action="store", help="feedstock path")
     parser.addoption("--arch", nargs="+", default=_DEFAULT_SUBDIRS)
     parser.addoption("--python", nargs="+", default=_DEFAULT_PYTHON)
-    parser.addoption("--channels", nargs="+", default=['default'])
+    parser.addoption("--channels", nargs="+", default=["default"])
     parser.addoption(
         "--aggregate",
         action="store",

--- a/percy/examples/preinstall/dry_run.py
+++ b/percy/examples/preinstall/dry_run.py
@@ -1,8 +1,9 @@
+import argparse
+import json
 import os
 import subprocess
 import sys
-import json
-import argparse
+
 
 def dry_run(
     subdir="linux-64",
@@ -12,8 +13,7 @@ def dry_run(
     override_channels=False,
     packages=[],
 ):
-    """ Dry-run an environment and return it's json result.
-    """
+    """Dry-run an environment and return it's json result."""
     cmd = f"conda create -n test_env --dry-run --json --experimental-solver={solver}"
     for channel in channels:
         cmd += f" -c {channel}"
@@ -38,9 +38,9 @@ def dry_run(
     json_result["__command__"] = {"cmd": " ".join(cmd), "env": conda_env}
     return json_result
 
+
 def dry_run_assert(subdir, packages):
-    """ Dry-run an environment and assert that it succeeds.
-    """
+    """Dry-run an environment and assert that it succeeds."""
     json_result = dry_run(
         subdir=subdir,
         channels=["defaults"],
@@ -57,17 +57,23 @@ def dry_run_assert(subdir, packages):
         message += f"\n\n{json.dumps(json_result, indent=4)}"
     assert json_result.get("success", False), message
 
+
 def create_parser() -> argparse.ArgumentParser:
-    """ Create command line parser.
-    """
+    """Create command line parser."""
     parser = argparse.ArgumentParser(
         prog="test_env",
         description="Dry-run an environment.",
     )
     parser.add_argument(
-        "-a", "--subdir", type=str, help="Subdir: e.g. linux-64", default="linux-64"
+        "-a",
+        "--subdir",
+        type=str,
+        help="Subdir: e.g. linux-64",
+        default="linux-64",
     )
-    parser.add_argument("-g", "--glibc", type=str, help="glibc version", default=None)
+    parser.add_argument(
+        "-g", "--glibc", type=str, help="glibc version", default=None
+    )
     parser.add_argument(
         "-s",
         "--solver",

--- a/percy/examples/py_buildorder/copy_to_www_pkgs_main.py
+++ b/percy/examples/py_buildorder/copy_to_www_pkgs_main.py
@@ -2,18 +2,18 @@
 """
 
 import argparse
-from pathlib import Path
-import requests
+import grp
 import json
 import logging
-
-import grp
 import os
 import pwd
 import shutil
 import sys
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import DefaultDict, List
+
+import requests
 
 ZEUS_DEST = Path("/www/pkgs/main")
 DEFAULT_PERMISSIONS = 0o664
@@ -84,7 +84,10 @@ def filter_repodata(subdir, local_dir):
                         m["name"] == v["name"]
                         and m["version"] == v["version"]
                         and m["build_number"] == v["build_number"]
-                        and ("python >=3.11,<3.12.0a0" in m["depends"] or "py311" in p)
+                        and (
+                            "python >=3.11,<3.12.0a0" in m["depends"]
+                            or "py311" in p
+                        )
                         for p, m in repodata_subdir_defaults["packages"].items()
                     ]
                 ):
@@ -95,7 +98,9 @@ def filter_repodata(subdir, local_dir):
                         return "mkl >=2021.4.0,<2022.0a0" in package["depends"]
 
                     if subdir == "osx-64" and depends_on_mkl(v):
-                        logger.warning(f"Skipping osx-64 mkl related package { k }")
+                        logger.warning(
+                            f"Skipping osx-64 mkl related package { k }"
+                        )
                         has_warnings = True
                         results["skip"].add(k)
                     else:
@@ -137,7 +142,9 @@ def filter_repodata(subdir, local_dir):
         fpathtarbz2 = ZEUS_DEST / subdir / k
         fpathconda = ZEUS_DEST / subdir / k.replace(".tar.bz2", ".conda")
         if fpathtarbz2.is_file() or fpathconda.is_file():
-            logger.warning(f"Package in target folder! {fpathtarbz2} {fpathconda}")
+            logger.warning(
+                f"Package in target folder! {fpathtarbz2} {fpathconda}"
+            )
             has_warnings = True
             filter_copied.add(fpathtarbz2)
             filter_copied.add(fpathconda)
@@ -180,7 +187,9 @@ def copy_files(files: DefaultDict[str, List[str]], dry_run: bool = True):
     try:
         group_id = grp.getgrnam(group_name).gr_gid
     except Exception:
-        copy_failed(f"Failed to obtain id for group '{group_name}'; terminating!")
+        copy_failed(
+            f"Failed to obtain id for group '{group_name}'; terminating!"
+        )
 
     for arch, list_of_files in files.items():
         final_path = ZEUS_DEST / arch
@@ -281,7 +290,9 @@ if __name__ == "__main__":
     parser = create_parser()
     args = parser.parse_args()
 
-    results, has_errors, has_warnings = filter_repodata(args.subdir, args.local_dir)
+    results, has_errors, has_warnings = filter_repodata(
+        args.subdir, args.local_dir
+    )
     if has_errors:
         logger.error("Errors were found. Abort...")
         if input("Do you wish to continue? (y/n)").lower() != "y":

--- a/percy/examples/py_buildorder/find_outdated_with_defaults.py
+++ b/percy/examples/py_buildorder/find_outdated_with_defaults.py
@@ -112,7 +112,9 @@ def compare_repodata(subdir, python_ref, python_target, block_list):
     results = {}
     for local_name, local in pkgs_local.items():
         defaults = pkgs_defaults.get(local_name)
-        if defaults and _is_newer_than(defaults, local["vo"], local["build_number"]):
+        if defaults and _is_newer_than(
+            defaults, local["vo"], local["build_number"]
+        ):
             results[local_name] = {
                 "312_version": local["version"],
                 "312_build_number": local["build_number"],
@@ -157,7 +159,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     block_list = []
-    filename = f"{args.subdir}/python_3.11_{args.subdir}_package_list_missing.yaml"
+    filename = (
+        f"{args.subdir}/python_3.11_{args.subdir}_package_list_missing.yaml"
+    )
     with open(filename) as file:
         block_list = yaml.safe_load(file)
 

--- a/percy/examples/py_buildorder/gen_python_build_order.py
+++ b/percy/examples/py_buildorder/gen_python_build_order.py
@@ -1,17 +1,19 @@
 """ Generate build scripts to build all packages depending on python.
 """
 
-import percy.render.aggregate as aggregate
-from config import block_list
-from config import extras_versions as extras
 import argparse
-from pathlib import Path
-from itertools import groupby
-import requests
 import json
 import os
 import shutil
+from itertools import groupby
+from pathlib import Path
+
+import requests
 import yaml
+from config import block_list
+from config import extras_versions as extras
+
+import percy.render.aggregate as aggregate
 
 
 def get_repodata_package_list(subdir, python_ref, include_noarch=False):
@@ -45,7 +47,9 @@ def get_repodata_package_list(subdir, python_ref, include_noarch=False):
         next_minor = str(int(python_ref.split(".")[-1]) + 1)
         for v in repo_package["depends"]:
             if v.find("python ") >= 0:
-                if v.find(hlp) >= 0 or match_lower(python_ref[0], next_minor, v):
+                if v.find(hlp) >= 0 or match_lower(
+                    python_ref[0], next_minor, v
+                ):
                     return True
             elif v.find(hlp2) >= 0:
                 return True
@@ -90,11 +94,19 @@ def get_repodata_package_list(subdir, python_ref, include_noarch=False):
 
 
 def gen_python_build_order(
-    aggregate_path, subdir, python_ref, python_target, numpy_target, croot, channel
+    aggregate_path,
+    subdir,
+    python_ref,
+    python_target,
+    numpy_target,
+    croot,
+    channel,
 ):
     # Helper to generate script names.
     def _script(script_name_ending):
-        return f"./{subdir}/python_{python_target}_{subdir}_{script_name_ending}"
+        return (
+            f"./{subdir}/python_{python_target}_{subdir}_{script_name_ending}"
+        )
 
     if croot is None:
         if not subdir.startswith("win-"):
@@ -105,7 +117,9 @@ def gen_python_build_order(
     os.makedirs(f"./{subdir}/", exist_ok=True)
 
     # load repodata package list
-    repodata_package_list = sorted(get_repodata_package_list(subdir, python_ref, False))
+    repodata_package_list = sorted(
+        get_repodata_package_list(subdir, python_ref, False)
+    )
     repodata_package_list_with_noarch = sorted(
         get_repodata_package_list(subdir, python_ref, True)
     )
@@ -124,7 +138,9 @@ def gen_python_build_order(
         yaml.dump(aggregate_repo.package_to_feedstock_path(), f)
 
     # get feedstock build order
-    allow_list = repodata_package_list  # only packages already in subdir defaults
+    allow_list = (
+        repodata_package_list  # only packages already in subdir defaults
+    )
     # only packages already in subdir and noarch defaults
     allow_list_noarch = repodata_package_list_with_noarch
     python_buildout = aggregate_repo.get_depends_build_order(
@@ -141,20 +157,31 @@ def gen_python_build_order(
         f"./{subdir}/python_{python_target}_{subdir}_package_list.yaml", "w"
     ) as f:
         yaml.dump(aggregate_package_list, f)
-    repodata_package_list = sorted(get_repodata_package_list(subdir, python_ref))
-    with open(f"./{subdir}/python_{python_ref}_{subdir}_package_list.yaml", "w") as f:
+    repodata_package_list = sorted(
+        get_repodata_package_list(subdir, python_ref)
+    )
+    with open(
+        f"./{subdir}/python_{python_ref}_{subdir}_package_list.yaml", "w"
+    ) as f:
         yaml.dump(repodata_package_list, f)
     with open(
-        f"./{subdir}/python_{python_ref}_{subdir}_package_list_missing.yaml", "w"
+        f"./{subdir}/python_{python_ref}_{subdir}_package_list_missing.yaml",
+        "w",
     ) as f:
         yaml.dump(
-            sorted(list(set(repodata_package_list) - set(aggregate_package_list))), f
+            sorted(
+                list(set(repodata_package_list) - set(aggregate_package_list))
+            ),
+            f,
         )
     with open(
         f"./{subdir}/python_{python_ref}_{subdir}_package_list_new.yaml", "w"
     ) as f:
         yaml.dump(
-            sorted(list(set(aggregate_package_list) - set(repodata_package_list))), f
+            sorted(
+                list(set(aggregate_package_list) - set(repodata_package_list))
+            ),
+            f,
         )
 
     # also export subdir + noarch list
@@ -165,11 +192,16 @@ def gen_python_build_order(
     for feedstock in python_buildout_with_noarch:
         for pkg_name in feedstock.packages.keys():
             aggregate_package_list_with_noarch.append(pkg_name)
-    aggregate_package_list_with_noarch = sorted(aggregate_package_list_with_noarch)
+    aggregate_package_list_with_noarch = sorted(
+        aggregate_package_list_with_noarch
+    )
     with open(f"./{subdir}/python_full_package_list.yaml", "w") as f:
         yaml.dump(
             dict(
-                map(lambda e: (e, [croot, channel]), aggregate_package_list_with_noarch)
+                map(
+                    lambda e: (e, [croot, channel]),
+                    aggregate_package_list_with_noarch,
+                )
             ),
             f,
         )
@@ -177,7 +209,8 @@ def gen_python_build_order(
 
     # write stage build scripts
     stages = [
-        list(result) for key, result in groupby(python_buildout, key=lambda f: f.weight)
+        list(result)
+        for key, result in groupby(python_buildout, key=lambda f: f.weight)
     ]
     n_stages = len(stages)
 
@@ -332,13 +365,25 @@ def create_parser() -> argparse.ArgumentParser:
         "-s", "--subdir", type=str, help="Architecture", default="linux-64"
     )
     parser.add_argument(
-        "-r", "--python-ref", type=str, help="Reference python version", default="3.11"
+        "-r",
+        "--python-ref",
+        type=str,
+        help="Reference python version",
+        default="3.11",
     )
     parser.add_argument(
-        "-p", "--python-target", type=str, help="Target python version", default="3.12"
+        "-p",
+        "--python-target",
+        type=str,
+        help="Target python version",
+        default="3.12",
     )
     parser.add_argument(
-        "-n", "--numpy-target", type=str, help="Target numpy version", default="1.25"
+        "-n",
+        "--numpy-target",
+        type=str,
+        help="Target numpy version",
+        default="1.25",
     )
     parser.add_argument(
         "-c",

--- a/percy/examples/py_buildorder/patch312.py
+++ b/percy/examples/py_buildorder/patch312.py
@@ -2,11 +2,12 @@
 
 """
 
-from pathlib import Path
+import copy
 import logging
 import re
-import copy
+from pathlib import Path
 from typing import Any
+
 from ruamel.yaml import YAML
 
 yaml = YAML(typ="jinja2")
@@ -36,7 +37,9 @@ class Recipe:
             self.meta = yaml.load(fp)
             self.packages = {}
             if not self.meta.get("outputs", []):
-                name = self.meta.get("package", {}).get("name", "unknown").strip()
+                name = (
+                    self.meta.get("package", {}).get("name", "unknown").strip()
+                )
                 self.packages[name] = ""
             else:
                 outputs = self.meta.get("outputs", [])
@@ -183,7 +186,9 @@ class Recipe:
                 # apply package specific operation for all packages
                 for package_path in self.packages.values():
                     opcopy = copy.deepcopy(op)
-                    opcopy["path"] = opcopy["path"].replace("@output/", package_path)
+                    opcopy["path"] = opcopy["path"].replace(
+                        "@output/", package_path
+                    )
                     self._patch(opcopy)
                     self.save()
                     self.reload()
@@ -237,14 +242,18 @@ class Recipe:
                 # finding range of direct parent
                 # (not doing the leg work of going up the tree if parent is not found)
                 try:
-                    (start_row, start_col, end_row, _) = self.get_raw_range(parent_path)
+                    (start_row, start_col, end_row, _) = self.get_raw_range(
+                        parent_path
+                    )
                 except KeyError:
                     logging.warning(f"Path not found while applying op:{opop}")
                 else:
                     # adding value to end of parent
                     # if value is a list, adding as a list to parent
                     # if value is a string, adding as parent: value
-                    parent_range = copy.deepcopy(self.meta_yaml[start_row:end_row])
+                    parent_range = copy.deepcopy(
+                        self.meta_yaml[start_row:end_row]
+                    )
                     parent_insert_index = 0
                     for i, e in reversed(list(enumerate(parent_range))):
                         if e.strip():
@@ -252,11 +261,13 @@ class Recipe:
                             break
                     if isinstance(value, list):
                         parent_range.insert(
-                            parent_insert_index, " " * start_col + f"{parent_name}:"
+                            parent_insert_index,
+                            " " * start_col + f"{parent_name}:",
                         )
                         for val in value:
                             parent_range.insert(
-                                parent_insert_index + 1, " " * start_col + f"  - {val}"
+                                parent_insert_index + 1,
+                                " " * start_col + f"  - {val}",
                             )
                     else:
                         parent_range.insert(
@@ -316,19 +327,22 @@ class Recipe:
             for new_val in value:
                 for i, m in match_lines.items():
                     to_insert.add(
-                        m.string.replace(m.groupdict()["pattern"], new_val).replace(
-                            "#", "  #", 1
-                        )
+                        m.string.replace(
+                            m.groupdict()["pattern"], new_val
+                        ).replace("#", "  #", 1)
                     )
             if not to_insert:
                 to_insert = set(value)
             for new_val in to_insert:
                 if in_list:
                     range.insert(
-                        insert_index, " " * start_col + f"- {new_val.strip(' -')}"
+                        insert_index,
+                        " " * start_col + f"- {new_val.strip(' -')}",
                     )
                 else:
-                    range.insert(insert_index, " " * start_col + f"{new_val.strip()}")
+                    range.insert(
+                        insert_index, " " * start_col + f"{new_val.strip()}"
+                    )
 
         # apply change
         self.meta_yaml[start_row:end_row] = range
@@ -353,53 +367,52 @@ class Recipe:
 
 
 if __name__ == "__main__":
-
     operations = [
         {
             "op": "replace",
             "path": "@output/requirements/host",
             "match": "cython\\s+0.29.\\d+",
-            "value": ["cython 0.29"]
+            "value": ["cython 0.29"],
         },
         {
             "op": "replace",
             "path": "@output/requirements/host",
             "match": "packaging\\s+2\\d.\\d",
-            "value": ["packaging 23"]
+            "value": ["packaging 23"],
         },
         {
             "op": "replace",
             "path": "@output/requirements/host",
             "match": "flit-core\\s+3.\\d.\\d",
-            "value": ["flit-core 3"]
+            "value": ["flit-core 3"],
         },
         {
             "op": "replace",
             "path": "@output/requirements/host",
             "match": "poetry-core\\s+1.5.\\d",
-            "value": ["poetry-core 1.5"]
+            "value": ["poetry-core 1.5"],
         },
         {
             "op": "replace",
             "path": "@output/requirements/host",
             "match": "hatchling\\s+1.\\d+.\\d",
-            "value": ["hatchling 1.18"]
+            "value": ["hatchling 1.18"],
         },
         {
             "op": "replace",
             "path": "@output/requirements/host",
             "match": "setuptools\\s+6\\d.\\d",
-            "value": ["setuptools"]
+            "value": ["setuptools"],
         },
         {
             "op": "replace",
             "path": "@output/requirements/host",
             "match": "setuptools_scm\\s+[\\d\\.]+",
-            "value": ["setuptools_scm"]
-        }
+            "value": ["setuptools_scm"],
+        },
     ]
 
-    p = Path('.')
+    p = Path(".")
     for recipe_path in p.glob("**/recipe/meta.yaml"):
         try:
             recipe = Recipe(str(recipe_path))

--- a/percy/examples/py_buildorder/test_install.py
+++ b/percy/examples/py_buildorder/test_install.py
@@ -9,8 +9,9 @@ Usage:
 """
 
 import json
-import pytest
 import subprocess
+
+import pytest
 import yaml
 
 

--- a/percy/render/_dumper.py
+++ b/percy/render/_dumper.py
@@ -1,5 +1,6 @@
 import sys
 from typing import List, TextIO
+
 import yaml
 from ruamel.yaml import YAML
 
@@ -15,7 +16,9 @@ ruamel.width = 1000
 ruamel.default_flow_style = False
 
 
-def _dump_render_results_ruamel(render_results: List, out: TextIO = sys.stdout) -> None:
+def _dump_render_results_ruamel(
+    render_results: List, out: TextIO = sys.stdout
+) -> None:
     """Dumps a list of rendered variants of a recipe.
 
     Args:
@@ -34,7 +37,9 @@ def _dump_render_results_ruamel(render_results: List, out: TextIO = sys.stdout) 
     ruamel.dump(data_to_dump, out)
 
 
-def _dump_render_results_yaml(render_results: List, out: TextIO = sys.stdout) -> None:
+def _dump_render_results_yaml(
+    render_results: List, out: TextIO = sys.stdout
+) -> None:
     """Dumps a list of rendered variants of a recipe.
 
     Args:
@@ -59,7 +64,11 @@ def _dump_render_results_yaml(render_results: List, out: TextIO = sys.stdout) ->
         fields = FIELDS
 
         def to_omap(self):
-            return [(field, self[field]) for field in _MetaYaml.fields if field in self]
+            return [
+                (field, self[field])
+                for field in _MetaYaml.fields
+                if field in self
+            ]
 
     def _represent_omap(dumper, data):
         return dumper.represent_mapping("tag:yaml.org,2002:map", data.to_omap())

--- a/percy/render/variants.py
+++ b/percy/render/variants.py
@@ -6,13 +6,14 @@ Largely inspired from conda build.
 # TODO: refactor long lines and remove the following linter mute
 # ruff: noqa: E501
 
+import copy
+import itertools
 import logging
 import os
 import re
-from typing import List, Sequence, Dict, Tuple
 from pathlib import Path
-import itertools
-import copy
+from typing import Dict, List, Sequence, Tuple
+
 import yaml
 
 try:
@@ -37,7 +38,9 @@ def _ensure_list(obj):
 
 
 # copied and adapted from conda-build
-def _find_config_files(metadata_or_path, variant_config_files, exclusive_config_files):
+def _find_config_files(
+    metadata_or_path, variant_config_files, exclusive_config_files
+):
     """
     Find config files to load. Config files are stacked in the following order:
         1. exclusive config files (see config.exclusive_config_files)
@@ -80,11 +83,15 @@ def _find_config_files(metadata_or_path, variant_config_files, exclusive_config_
             files.append(cfg)
         else:
             path = getattr(metadata_or_path, "path", metadata_or_path)
-            cfg = resolve(os.path.join(path, "..", "..", "conda_build_config.yaml"))
+            cfg = resolve(
+                os.path.join(path, "..", "..", "conda_build_config.yaml")
+            )
             if os.path.isfile(cfg):
                 files.append(cfg)
             else:
-                cfg = resolve(os.path.join(path, "..", "conda_build_config.yaml"))
+                cfg = resolve(
+                    os.path.join(path, "..", "conda_build_config.yaml")
+                )
                 if os.path.isfile(cfg):
                     files.append(cfg)
 
@@ -119,7 +126,9 @@ def _apply_selector(data, selector_dict):
     for line in data.splitlines():
         if (match := re.search(r"^(\s*)#.*$", line)) is not None:
             line = f"{match.group(1)}# comment "  # <-- this is to ignore potential bad jinja in comments
-        elif (match := re.search(r"(\s*)[^#].*(#\s*\[([^\]]*)\].*)", line)) is not None:
+        elif (
+            match := re.search(r"(\s*)[^#].*(#\s*\[([^\]]*)\].*)", line)
+        ) is not None:
             cond_str = match.group(3)
             try:
                 if not eval(cond_str, None, selector_dict):
@@ -267,7 +276,8 @@ def read_conda_build_config(
         if groups:
             group_keys, group_values = zip(*groups.items())
             group_permutations = [
-                dict(zip(group_keys, v)) for v in itertools.product(*group_values)
+                dict(zip(group_keys, v))
+                for v in itertools.product(*group_values)
             ]
             for d in group_permutations:
                 new_d = copy.deepcopy(d)
@@ -305,7 +315,9 @@ def read_conda_build_config(
                 if isinstance(v, list):
                     variant_selector_dict[k] = v[0]
             if "python" in variant_selector_dict:
-                python_short = str(variant_selector_dict["python"]).replace(".", "")
+                python_short = str(variant_selector_dict["python"]).replace(
+                    ".", ""
+                )
                 variant_selector_dict["py"] = int(python_short)
                 variant_selector_dict[f"py{python_short}"] = True
             perm["subdir"] = arch

--- a/percy/repodata/repodata.py
+++ b/percy/repodata/repodata.py
@@ -1,8 +1,10 @@
-import requests
 import json
 import logging
-from conda.models.version import VersionOrder
+
+import requests
 from conda.exceptions import InvalidVersionSpec
+from conda.models.version import VersionOrder
+
 from percy.render.recipe import Package
 
 
@@ -44,7 +46,8 @@ def get_latest_package_list(
                 or (
                     VersionOrder(pkgs_noarch[v["name"]]["version"])
                     == VersionOrder(v["version"])
-                    and pkgs_noarch[v["name"]]["build_number"] < v["build_number"]
+                    and pkgs_noarch[v["name"]]["build_number"]
+                    < v["build_number"]
                 )
             ):
                 pkgs_noarch[v["name"]] = {
@@ -95,7 +98,8 @@ def get_latest_package_list(
                 or (
                     VersionOrder(info["version"])
                     == VersionOrder(pkgs_defaults[name]["version"])
-                    and info["build_number"] > pkgs_defaults[name]["build_number"]
+                    and info["build_number"]
+                    > pkgs_defaults[name]["build_number"]
                 )
             ):
                 logging.info(f"Found newer noarch {name} {pkgs_noarch[name]}")
@@ -124,8 +128,12 @@ def compare_package_with_defaults(
         local_build_number = int(package.number)
         if local_name in defaults_pkgs:
             defaults_version = defaults_pkgs[local_name]["version"]
-            defaults_build_number = int(defaults_pkgs[local_name]["build_number"])
-            if (VersionOrder(local_version) < VersionOrder(defaults_version)) or (
+            defaults_build_number = int(
+                defaults_pkgs[local_name]["build_number"]
+            )
+            if (
+                VersionOrder(local_version) < VersionOrder(defaults_version)
+            ) or (
                 VersionOrder(local_version) == VersionOrder(defaults_version)
                 and local_build_number < defaults_build_number
             ):


### PR DESCRIPTION
This PR contains no human changes, outside of edits to the `Makefile`.

I ran `black` and `isort` against the entire project, in preparation for a future linting fix PR.

From this point forward, `black` and `isort` will run against all files in Percy.

`black` and `isort` have been configured to play nice with each other AND to work without fighting against the `pylintrc` file we've adapted from Google's linting rules.