### PR TITLE
Allows users to A/B test the new parse-tree work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CONDA_ACTIVATE = source $$(conda info --base)/etc/profile.d/conda.sh ; conda act
 # commands.
 PYTHON3 := $(shell which python3)
 
-.PHONY: clean clean-env clean-test clean-pyc clean-build clean-other help dev test test-cov pre-commit lint format analyze
+.PHONY: clean clean-env clean-test clean-pyc clean-build clean-other help dev test test-debug test-cov pre-commit lint format analyze
 .DEFAULT_GOAL := help
 
 CONDA_ENV_NAME ?= percy
@@ -95,6 +95,9 @@ pre-commit:     ## runs pre-commit against files. NOTE: older files are disabled
 
 test:			## runs test cases
 	$(PYTHON3) -m pytest --capture=no percy/tests/
+
+test-debug:		## runs test cases with debugging info enabled
+	$(PYTHON3) -m pytest -vv --capture=no percy/tests/
 
 test-cov:		## checks test coverage requirements
 	$(PYTHON3) -m pytest --cov-config=.coveragerc --cov=percy percy/tests/ --cov-fail-under=10 --cov-report term-missing

--- a/percy/tests/test_aux_files/patch_files/simple-recipe_patch_replace.json
+++ b/percy/tests/test_aux_files/patch_files/simple-recipe_patch_replace.json
@@ -1,0 +1,36 @@
+[
+    {
+        "op": "replace",
+        "path": "/build/number",
+        "value": 42
+    },
+    {
+        "op": "replace",
+        "path": "/build/is_true",
+        "value": false
+    },
+    {
+        "op": "replace",
+        "path": "/about/license",
+        "value": "MIT"
+    },
+    {
+        "op": "replace",
+        "path": "/requirements/run/0",
+        "value": "cpython"
+    },
+    {
+        "op": "replace",
+        "path": "/about/summary",
+        "value": [
+            "The Trial",
+            "Never Ends",
+            "Picard"
+        ]
+    },
+    {
+        "op": "replace",
+        "path": "/about/description",
+        "value": "This is a PEP 561\ntype stub package\nfor the toml package."
+    }
+]


### PR DESCRIPTION
- Adds some new functionality to the `Recipe` class so that callers can utilize some of the newest features of the parse-tree effort.
- These changes are intended to ensure backwards compatibility and reduce the "blast radius" to zero or near zero. Current code in operation will not be opted-in to these changes. A user must explicitly opt-in.

Manual testing with the `recipe` command was performed to ensure the CLI works as expected with the new `--parse_tree` flag.

I argue that once this is in, we should bump percy to the next version so `AnacondaLinter` can start using the parse tree work.