### PR TITLE
Add support for Patch Ops add/remove

### DIFF
--- a/percy/render/recipe_parser.py
+++ b/percy/render/recipe_parser.py
@@ -46,7 +46,7 @@ _StrStack = list[str]
 _StrStackImmutable = tuple[str]
 
 # Type alias for a table that maps operations to functions.
-_OpsTable = dict[str, Callable[[str, _StrStack, JsonType], bool]]
+_OpsTable = dict[str, Callable[[str, _StrStack, Optional[JsonType]], bool]]
 
 # Indicates how many spaces are in a level of indentation
 TAB_SPACE_COUNT: Final[str] = 2
@@ -89,16 +89,10 @@ JSON_PATCH_SCHEMA: Final[SchemaType] = {
         "path",
     ],
     "allOf": [
-        # `value` is required for `add`/`remove`/`replace`/`test`
+        # `value` is required for `add`/`replace`/`test`
         {
             "if": {
                 "properties": {"op": {"const": "add"}},
-            },
-            "then": {"required": ["value"]},
-        },
-        {
-            "if": {
-                "properties": {"op": {"const": "remove"}},
             },
             "then": {"required": ["value"]},
         },
@@ -337,13 +331,20 @@ class _Traverse:
             path_idx = int(path_part)
             if path_idx < 0 or path_idx > max_idx:
                 return None
+            # Edge case: someone attempts to use the index syntax on a non-list
+            # member. As children are stored as a list per node, this could "work"
+            # with unintended consequences. In other words, users could accidentally
+            # abuse underlying implementation details.
+            if not node.children[path_idx].list_member_flag:
+                return None
+
             path.pop()
             return _Traverse._traverse_recurse(node.children[path_idx], path)
 
         for child in node.children:
             # Remember: for nodes that represent part of the path, the "value"
             # stored in the node is part of the path-name.
-            if child.value == path[-1]:
+            if child.value == path_part:
                 path.pop()
                 return _Traverse._traverse_recurse(child, path)
         # Path not found
@@ -373,6 +374,35 @@ class _Traverse:
         # Purge `root` from the path
         path.pop()
         return _Traverse._traverse_recurse(node, path)
+
+    @staticmethod
+    def traverse_with_index(root: _Node, path: _StrStack) -> tuple[Optional[_Node], int]:
+        """
+        Given a path, return the node of interest OR the parent node with
+        indexing information, if the node is in a list.
+        :param root:    Starting node of the tree/branch to traverse.
+        :param path:    Path, as a stack, that describes a location in the tree.
+        :return: A tuple containing two items:
+                   - `_Node` object if a node is found in the parse tree at that
+                     path. Otherwise returns `None`. If the path terminates in
+                     an index, the parent is returned with the index location.
+                   - If the node is a member of a list, the index returned will
+                     be >= 0.
+        """
+        if len(path) == 0:
+            return None
+
+        node: _Node
+        node_idx: int = -1
+        # Pre-determine if the path is targeting a list position. Patching
+        # only applies on the last index provided.
+        if path[0].isdigit():
+            # Find the index position of the target on the parent's list
+            node_idx = int(path.pop(0))
+
+        node = _Traverse.traverse(root, path)
+
+        return node, node_idx
 
     @staticmethod
     def traverse_all(
@@ -876,10 +906,11 @@ class RecipeParser:
             # Empty keys can be easily confused for leaf nodes. The difference
             # is these nodes render with a "dangling" `:` mark
             elif child.is_empty_key():
+                # Top-level empty-key edge case: Top level keys should have no
+                # additional indentation.
+                extra_tab = "" if depth < 0 else TAB_AS_SPACES
                 lines.append(
-                    f"{spaces}{TAB_AS_SPACES}"
-                    f"{RecipeParser._stringify_yaml(child.value)}:  "
-                    f"{child.comment}".rstrip()
+                    f"{spaces}{extra_tab}" f"{RecipeParser._stringify_yaml(child.value)}:  " f"{child.comment}".rstrip()
                 )
             # Leaf nodes are rendered as members in a list
             elif child.is_leaf():
@@ -1175,34 +1206,114 @@ class RecipeParser:
 
     # TODO complete: set/add and remove selectors
 
-    def _patch_replace(self, _: str, path_stack: _StrStack, value: JsonType) -> bool:
+    @staticmethod
+    def _is_valid_patch_node(node: _Node, node_idx: int) -> bool:
         """
-        Performs a JSON patch `replace` operation.
-        :param path_stack:  Path that describes a location in the tree, as a
-                            list, treated like a stack.
-        :param value:   Value to update with.
-        :raises UnsupportedOpException: If the operation preformed is not
-                                        supported. TODO Exception will no longer
-                                        be raised when support is added.
+        Indicates if the target node to perform a patch operation against is
+        a valid node. This is based on the RFC spec for JSON patching paths.
+        :param node:        Target node to validate
+        :param node_idx:    If caller is evaluating if a list member, exists,
+                            this is the index into that list. Otherwise this
+                            value should be less than 0.
+        :return: True if the node can be patched. False otherwise.
         """
-        node: _Node
-        node_idx: int = -1
-        # Pre-determine if the path is targeting a list position. Patching
-        # only applies on the last index provided.
-        if path_stack[0].isdigit():
-            # Find the index and parent of the target
-            node_idx = int(path_stack.pop(0))
-            node = _Traverse.traverse(self._root, path_stack)
-        else:
-            node = _Traverse.traverse(self._root, path_stack)
         # Path not found
         if node is None:
             return False
 
         # Leaf nodes contain values and not path information. Paths should
         # not be made that access leaf nodes, with the exception of members
-        # of a list. Making such a path violates the RFC.
-        if not node.list_member_flag and node.is_leaf():
+        # of a list and keys. Making such a path violates the RFC.
+        if not node.list_member_flag and not node.key_flag and node.is_leaf():
+            return False
+
+        # Check the bounds if the target requires the use of an index.
+        if node_idx >= 0 and node_idx > (len(node.children) - 1):
+            return False
+
+        return True
+
+    def _patch_add(self, _: str, path_stack: _StrStack, value: JsonType) -> bool:
+        """
+        Performs a JSON patch `add` operation.
+        :param path_stack:  Path that describes a location in the tree, as a
+                            list, treated like a stack.
+        :param value:       Value to add.
+        """
+        if len(path_stack) == 0:
+            return False
+
+        # Special case that only applies to `add`. The `-` character indicates
+        # the new element can be added to the end of the list.
+        append_to_list = False
+        if path_stack[0] == "-":
+            path_stack.pop(0)
+            append_to_list = True
+
+        node, node_idx = _Traverse.traverse_with_index(self._root, path_stack)
+        if not RecipeParser._is_valid_patch_node(node, node_idx):
+            return False
+
+        new_children: Final[list[_Node]] = RecipeParser._generate_subtree(value)
+        # Mark children as list members if they are list members
+        if append_to_list or node_idx >= 0:
+            for child in new_children:
+                child.list_member_flag = True
+
+        # Insert members if an index is specified. Otherwise, extend the list of
+        # child nodes from the existing list.
+        if node_idx >= 0:
+            node.children[node_idx:node_idx] = new_children
+        else:
+            node.children.extend(new_children)
+
+        return True
+
+    def _patch_remove(
+        self, _0: str, path_stack: _StrStack, _1: Optional[JsonType]  # pylint: disable=invalid-name
+    ) -> bool:
+        """
+        Performs a JSON patch `remove` operation.
+        :param path_stack:  Path that describes a location in the tree, as a
+                            list, treated like a stack.
+        """
+        if len(path_stack) == 0:
+            return False
+
+        # Removal in all scenarios requires targeting the parent node.
+        node_idx = -1 if not path_stack[0].isdigit() else int(path_stack[0])
+        # `traverse()` is destructive to the stack, so make a copy for the second
+        # traversal call.
+        path_stack_copy = path_stack.copy()
+        node_to_rm = _Traverse.traverse(self._root, path_stack)
+        path_stack_copy.pop(0)
+        node = _Traverse.traverse(self._root, path_stack_copy)
+
+        if not RecipeParser._is_valid_patch_node(node_to_rm, -1) or not RecipeParser._is_valid_patch_node(
+            node, node_idx
+        ):
+            return False
+
+        if node_idx >= 0:
+            node.children.pop(node_idx)
+            return True
+
+        # In all other cases, the node to be removed must be found before eviction
+        for i in range(len(node.children)):
+            if node.children[i] == node_to_rm:
+                node.children.pop(i)
+                return True
+        return False
+
+    def _patch_replace(self, _: str, path_stack: _StrStack, value: JsonType) -> bool:
+        """
+        Performs a JSON patch `replace` operation.
+        :param path_stack:  Path that describes a location in the tree, as a
+                            list, treated like a stack.
+        :param value:       Value to update with.
+        """
+        node, node_idx = _Traverse.traverse_with_index(self._root, path_stack)
+        if not RecipeParser._is_valid_patch_node(node, node_idx):
             return False
 
         new_children: Final[list[_Node]] = RecipeParser._generate_subtree(value)
@@ -1216,7 +1327,7 @@ class RecipeParser:
             node.children.pop(node_idx + len(new_children))
             return True
 
-        # Leaves that represent values/paths of values can evict all
+        # Leafs that represent values/paths of values can evict all
         # children, and be replaced with new children, derived from a new
         # tree of values.
         node.children = new_children
@@ -1225,8 +1336,8 @@ class RecipeParser:
     def _patch_test(self, path: str, _: _StrStack, value: JsonType) -> bool:
         """
         Performs a JSON patch `test` operation.
-        :param path:        Path as a string. Useful for invoking public
-                            class members.
+        :param path:    Path as a string. Useful for invoking public
+                        class members.
         :param value:   Value to evaluate against.
         """
         try:
@@ -1244,6 +1355,8 @@ class RecipeParser:
         operations are currently available AND simplifies "switch"-like logic.
         """
         return {
+            "add": self._patch_add,
+            "remove": self._patch_remove,
             "replace": self._patch_replace,
             "test": self._patch_test,
         }
@@ -1299,8 +1412,9 @@ class RecipeParser:
         value_from: Final[str] = "value" if op in RecipeParser._patch_ops_requiring_value else "from"
         # Both versions of the path are sent over so that the op can easily use
         # both private and public functions (without incurring even more
-        # conversions between path types).
-        is_successful = supported_patch_ops[op](path, path_stack, patch[value_from])
+        # conversions between path types). NOTE: The `remove` op has no `value`
+        # or `from` field to pass in.
+        is_successful = supported_patch_ops[op](path, path_stack, None if op == "remove" else patch[value_from])
 
         # Update the selector table and modified flag, if the operation
         # succeeded.

--- a/percy/tests/test_aux_files/simple-recipe.yaml
+++ b/percy/tests/test_aux_files/simple-recipe.yaml
@@ -23,7 +23,7 @@ requirements:
 about:
   summary: This is a small recipe for testing
   description: |
-    This is a PEP 561 type stub package for the toml package.
+    This is a PEP '561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
@@ -1,0 +1,52 @@
+{% set zz_non_alpha_first = 42 %}
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}  # [unix]
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  is_true: true
+
+requirements:
+  empty_field1:
+  host:
+    - setuptools  # [unix]
+    - fakereq  # [unix]
+  empty_field2:
+  run:
+    - python
+  empty_field3:
+
+about:
+  summary: This is a small recipe for testing
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+
+multi_level:
+  list_1:
+    - foo
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - bat
+    - mat
+  list_3:
+    - ls
+    - sl
+    - cowsay
+
+test_var_usage:
+  foo: {{ version }}
+  bar:
+    - baz
+    - {{ zz_non_alpha_first }}
+    - blah
+    - This {{ name }} is silly
+    - last

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
@@ -4,18 +4,20 @@
 
 package:
   name: {{ name|lower }}  # [unix]
+  is_cool_name: true
 
 build:
   number: 0
   skip: true  # [py<37]
   is_true: true
+  meaning_of_life: 42
 
 requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix]
-  empty_field2:
+  empty_field2: Not so empty now
   run:
     - python
   empty_field3:
@@ -23,18 +25,21 @@ requirements:
 about:
   summary: This is a small recipe for testing
   description: |
-    This is a PEP 561 type stub package for the toml package.
+    This is a PEP '561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
 
 multi_level:
   list_1:
+    - "There's just one place to go for all your spatula needs!"
     - foo
     # Ensure a comment in a list is supported
     - bar
+    - Spatula City!
   list_2:
     - cat
+    - We got it all on UHF
     - bat
     - mat
   list_3:
@@ -50,3 +55,15 @@ test_var_usage:
     - blah
     - This {{ name }} is silly
     - last
+  Stanley:
+    - "Oh, Joel Miller, you've just found the marble in the oatmeal."
+    - "You're a lucky, lucky, lucky little boy."
+    - "'Cause you know why?"
+    - You get to drink from... the FIRE HOOOOOSE!
+
+U62:
+  George:
+    - "How'd you like your own TV show?"
+    - "You're on"
+  Stanley:
+    - Ok

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
@@ -1,0 +1,35 @@
+{% set zz_non_alpha_first = 42 %}
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+
+build:
+  skip: true  # [py<37]
+  is_true: true
+
+requirements:
+  empty_field1:
+  host:
+    - setuptools  # [unix]
+    - fakereq  # [unix]
+  run:
+    - python
+  empty_field3:
+
+multi_level:
+  list_1:
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - mat
+
+test_var_usage:
+  foo: {{ version }}
+  bar:
+    - baz
+    - {{ zz_non_alpha_first }}
+    - blah
+    - This {{ name }} is silly
+    - last

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -643,7 +643,7 @@ def test_patch_test() -> None:
 
 def test_patch_add() -> None:
     """
-    Tests the `remove` patch op.
+    Tests the `add` patch op.
     """
     parser = load_recipe("simple-recipe.yaml")
 

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -19,7 +19,7 @@ TEST_FILES_PATH = "percy/tests/test_aux_files"
 # Long multi-line description string found in the `simple-recipe.yaml` test file
 SIMPLE_DESCRIPTION: Final[
     str
-] = "This is a PEP 561 type stub package for the toml package.\nIt can be used by type-checking tools like mypy, pyright,\npytype, PyCharm, etc. to check code that uses toml."  # pylint: disable=line-too-long
+] = "This is a PEP '561 type stub package for the toml package.\nIt can be used by type-checking tools like mypy, pyright,\npytype, PyCharm, etc. to check code that uses toml."  # pylint: disable=line-too-long
 
 
 def load_file(file: Path | str) -> str:
@@ -451,15 +451,6 @@ def test_patch_path_invalid() -> None:
         parser.patch(
             {
                 "op": "add",
-                "path": "/build/skip/true",
-                "value": False,
-            }
-        )
-    )
-    assert not (
-        parser.patch(
-            {
-                "op": "add",
                 "path": "/multi_level/list2/4",
                 "value": 42,
             }
@@ -656,6 +647,101 @@ def test_patch_add() -> None:
     """
     parser = load_recipe("simple-recipe.yaml")
 
+    # As per the RFC, `add` will not construct multiple-levels of non-existing
+    # structures. The containing object(s)/list(s) must exist.
+    assert not parser.patch(
+        {
+            "op": "add",
+            "path": "/build/fake/meaning_of_life",
+            "value": 42,
+        }
+    )
+    # Similarly, appending to a list
+    assert not parser.patch(
+        {
+            "op": "add",
+            "path": "/requirements/empty_field1/-/blah",
+            "value": 42,
+        }
+    )
+    assert not parser.is_modified()
+
+    # Add primitive values
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/build/meaning_of_life",
+            "value": 42,
+        }
+    )
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/package/is_cool_name",
+            "value": True,
+        }
+    )
+
+    # Add to empty-key node
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/requirements/empty_field2",
+            "value": "Not so empty now",
+        }
+    )
+
+    # Add list items
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/multi_level/list_2/1",
+            "value": "We got it all on UHF",
+        }
+    )
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/multi_level/list_1/0",
+            "value": "There's just one place to go for all your spatula needs!",
+        }
+    )
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/multi_level/list_1/-",
+            "value": "Spatula City!",
+        }
+    )
+
+    # Add a complex value
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/test_var_usage",
+            "value": {
+                "Stanley": [
+                    "Oh, Joel Miller, you've just found the marble in the oatmeal.",
+                    "You're a lucky, lucky, lucky little boy.",
+                    "'Cause you know why?",
+                    "You get to drink from... the FIRE HOOOOOSE!",
+                ]
+            },
+        }
+    )
+
+    # Add a top-level complex value
+    assert parser.patch(
+        {
+            "op": "add",
+            "path": "/U62",
+            "value": {
+                "George": ["How'd you like your own TV show?", "You're on"],
+                "Stanley": ["Ok"],
+            },
+        }
+    )
+
     # Sanity check: validate all modifications
     assert parser.is_modified()
     assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_add.yaml")
@@ -666,6 +752,7 @@ def test_patch_remove() -> None:
     Tests the `remove` patch op.
     """
     parser = load_recipe("simple-recipe.yaml")
+
     # Remove primitive values
     assert parser.patch(
         {
@@ -679,6 +766,7 @@ def test_patch_remove() -> None:
             "path": "/package/name",
         }
     )
+
     # Remove empty-key node
     assert parser.patch(
         {
@@ -850,7 +938,7 @@ def test_diff() -> None:
         "   empty_field1:\n"
         "@@ -26,7 +26,7 @@\n"
         "\n"
-        "     This is a PEP 561 type stub package for the toml package.\n"
+        "     This is a PEP '561 type stub package for the toml package.\n"
         "     It can be used by type-checking tools like mypy, pyright,\n"
         "     pytype, PyCharm, etc. to check code that uses toml.\n"
         "-  license: Apache-2.0 AND MIT\n"

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -376,13 +376,6 @@ def test_patch_schema_validation() -> None:
     with pytest.raises(recipe_parser.JsonPatchValidationException):
         parser.patch(
             {
-                "op": "remove",
-                "path": "/build/number",
-            }
-        )
-    with pytest.raises(recipe_parser.JsonPatchValidationException):
-        parser.patch(
-            {
                 "op": "replace",
                 "path": "/build/number",
             }
@@ -415,13 +408,124 @@ def test_patch_schema_validation() -> None:
         parser.patch({"op": "move", "path": "/build/number", "from": 42})
 
 
-def test_patch_path_not_found() -> None:
+def test_patch_path_invalid() -> None:
     """
     Tests if `patch` returns false on all ops when the path is not found.
     Also checks if the tree has been modified.
     """
     parser = load_recipe("simple-recipe.yaml")
 
+    # Passing an empty path fails at the JSON schema validation layer, so it
+    # applies to all patch functions.
+    with pytest.raises(recipe_parser.JsonPatchValidationException):
+        assert not (
+            parser.patch(
+                {
+                    "op": "test",
+                    "path": "",
+                    "value": 42,
+                }
+            )
+        )
+
+    # add
+    assert not (
+        parser.patch(
+            {
+                "op": "add",
+                "path": "/package/path/to/fake/value",
+                "value": 42,
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "add",
+                "path": "/build/number/0",
+                "value": 42,
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "add",
+                "path": "/build/skip/true",
+                "value": False,
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "add",
+                "path": "/multi_level/list2/4",
+                "value": 42,
+            }
+        )
+    )
+    # remove
+    assert not (
+        parser.patch(
+            {
+                "op": "remove",
+                "path": "/package/path/to/fake/value",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "remove",
+                "path": "/build/number/0",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "remove",
+                "path": "/multi_level/list2/4",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "remove",
+                "path": "/build/skip/true",
+            }
+        )
+    )
+    # replace
+    assert not (
+        parser.patch(
+            {
+                "op": "replace",
+                "path": "/build/number/0",
+                "value": 42,
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "replace",
+                "path": "/multi_level/list2/4",
+                "value": 42,
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "replace",
+                "path": "/build/skip/true",
+                "value": 42,
+            }
+        )
+    )
     assert not (
         parser.patch(
             {
@@ -431,6 +535,7 @@ def test_patch_path_not_found() -> None:
             }
         )
     )
+    # test
     assert not (
         parser.patch(
             {
@@ -545,6 +650,78 @@ def test_patch_test() -> None:
     assert not parser.is_modified()
 
 
+def test_patch_add() -> None:
+    """
+    Tests the `remove` patch op.
+    """
+    parser = load_recipe("simple-recipe.yaml")
+
+    # Sanity check: validate all modifications
+    assert parser.is_modified()
+    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_add.yaml")
+
+
+def test_patch_remove() -> None:
+    """
+    Tests the `remove` patch op.
+    """
+    parser = load_recipe("simple-recipe.yaml")
+    # Remove primitive values
+    assert parser.patch(
+        {
+            "op": "remove",
+            "path": "/build/number",
+        }
+    )
+    assert parser.patch(
+        {
+            "op": "remove",
+            "path": "/package/name",
+        }
+    )
+    # Remove empty-key node
+    assert parser.patch(
+        {
+            "op": "remove",
+            "path": "/requirements/empty_field2",
+        }
+    )
+
+    # Remove list items
+    assert parser.patch(
+        {
+            "op": "remove",
+            "path": "/multi_level/list_2/1",
+        }
+    )
+    assert parser.patch(
+        {
+            "op": "remove",
+            "path": "/multi_level/list_1/0",
+        }
+    )
+
+    # Remove a complex value
+    assert parser.patch(
+        {
+            "op": "remove",
+            "path": "/multi_level/list_3",
+        }
+    )
+
+    # Remove a top-level complex value
+    assert parser.patch(
+        {
+            "op": "remove",
+            "path": "/about",
+        }
+    )
+
+    # Sanity check: validate all modifications
+    assert parser.is_modified()
+    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_remove.yaml")
+
+
 def test_patch_replace() -> None:
     """
     Tests the `replace` patch op.
@@ -620,7 +797,12 @@ def test_patch_replace() -> None:
 
 
 ## Diff ##
+
+
 def test_diff() -> None:
+    """
+    Tests diffing output function
+    """
     parser = load_recipe("simple-recipe.yaml")
     # Ensure a lack of a diff works
     assert parser.diff() == ""


### PR DESCRIPTION
- Adds support for `add`/`remove` in `RecipeParser.patch()`
- Adds unit testing
- `add` supports `append`, as per the RFC with the `-` character
- Fixes the quote bug described in PKG-2982