### PR TITLE
Adds `move` and `copy` ops to patch, bug fixes

### DIFF
--- a/percy/render/recipe_parser.py
+++ b/percy/render/recipe_parser.py
@@ -519,8 +519,9 @@ class RecipeParser:
         :param subs:    List of substitutions to make, in order of appearance
         :return: New string, with substitutions removed
         """
-        for sub in subs:
-            s = s.replace(_PERCY_SUB_MARKER, sub, 1)
+        while s.find(_PERCY_SUB_MARKER) >= 0 and len(subs):
+            s = s.replace(_PERCY_SUB_MARKER, subs[0], 1)
+            subs.pop(0)
         return s
 
     @staticmethod
@@ -556,7 +557,7 @@ class RecipeParser:
     @staticmethod
     def _parse_yaml(s: str) -> JsonType:
         """
-        Parse a line of YAML into a Pythonic data structure
+        Parse a line (or multiple) of YAML into a Pythonic data structure
         :param s:   String to parse
         :return: Pythonic data corresponding to the line of YAML
         """
@@ -578,13 +579,11 @@ class RecipeParser:
             if isinstance(output, str):
                 output = RecipeParser._substitute_markers(output, sub_list)
             if isinstance(output, dict):
-                key = list(output.keys())[0]
-                output[key] = RecipeParser._substitute_markers(output[key], sub_list)
+                for key in output.keys():
+                    output[key] = RecipeParser._substitute_markers(output[key], sub_list)
             elif isinstance(output, list):
-                output[0] = RecipeParser._substitute_markers(output[0], sub_list)
-            else:
-                # TODO throw
-                pass
+                for i in range(len(output)):
+                    output[i] = RecipeParser._substitute_markers(output[i], sub_list)
         return output
 
     @staticmethod

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_copy.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_copy.yaml
@@ -4,26 +4,26 @@
 
 package:
   name: {{ name|lower }}  # [unix]
-  is_cool_name: true
 
 build:
   number: 0
   skip: true  # [py<37]
-  is_true: true
-  meaning_of_life: 42
+  is_true: ls
 
 requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix]
-  empty_field2: Not so empty now
+    - foo
+  empty_field2:
   run:
     - python
   empty_field3:
+  number: 0
 
 about:
-  summary: 62
+  summary: This is a small recipe for testing
   description: |
     This is a PEP '561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
@@ -32,20 +32,24 @@ about:
 
 multi_level:
   list_1:
-    - "There's just one place to go for all your spatula needs!"
     - foo
     # Ensure a comment in a list is supported
     - bar
-    - Spatula City!
   list_2:
+    - bat
     - cat
-    - We got it all on UHF
     - bat
     - mat
   list_3:
     - ls
     - sl
     - cowsay
+  bar:
+    - baz
+    - {{ zz_non_alpha_first }}
+    - blah
+    - This {{ name }} is silly
+    - last
 
 test_var_usage:
   foo: {{ version }}
@@ -55,15 +59,3 @@ test_var_usage:
     - blah
     - This {{ name }} is silly
     - last
-  Stanley:
-    - "Oh, Joel Miller, you've just found the marble in the oatmeal."
-    - "You're a lucky, lucky, lucky little boy."
-    - "'Cause you know why?"
-    - You get to drink from... the FIRE HOOOOOSE!
-
-U62:
-  George:
-    - "How'd you like your own TV show?"
-    - "You're on"
-  Stanley:
-    - Ok

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_copy.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_copy.yaml
@@ -15,7 +15,7 @@ requirements:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix]
-    - foo
+    - bar
   empty_field2:
   run:
     - python

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
@@ -4,26 +4,25 @@
 
 package:
   name: {{ name|lower }}  # [unix]
-  is_cool_name: true
 
 build:
-  number: 0
   skip: true  # [py<37]
-  is_true: true
-  meaning_of_life: 42
+  is_true: ls
 
 requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix]
-  empty_field2: Not so empty now
+    - bar
+  empty_field2:
   run:
     - python
   empty_field3:
+  number: 0
 
 about:
-  summary: 62
+  summary: This is a small recipe for testing
   description: |
     This is a PEP '561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
@@ -32,38 +31,21 @@ about:
 
 multi_level:
   list_1:
-    - "There's just one place to go for all your spatula needs!"
     - foo
     # Ensure a comment in a list is supported
-    - bar
-    - Spatula City!
   list_2:
-    - cat
-    - We got it all on UHF
     - bat
+    - cat
     - mat
   list_3:
-    - ls
     - sl
     - cowsay
-
-test_var_usage:
-  foo: {{ version }}
   bar:
     - baz
     - {{ zz_non_alpha_first }}
     - blah
     - This {{ name }} is silly
     - last
-  Stanley:
-    - "Oh, Joel Miller, you've just found the marble in the oatmeal."
-    - "You're a lucky, lucky, lucky little boy."
-    - "'Cause you know why?"
-    - You get to drink from... the FIRE HOOOOOSE!
 
-U62:
-  George:
-    - "How'd you like your own TV show?"
-    - "You're on"
-  Stanley:
-    - Ok
+test_var_usage:
+  foo: {{ version }}

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
@@ -19,10 +19,10 @@ requirements:
 
 multi_level:
   list_1:
+    - foo
     # Ensure a comment in a list is supported
-    - bar
   list_2:
-    - cat
+    - bat
     - mat
 
 test_var_usage:

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -1110,7 +1110,6 @@ def test_patch_copy() -> None:
     )
 
     # Copying list item to a different list
-    # TODO fix
     assert parser.patch(
         {
             "op": "copy",
@@ -1136,12 +1135,6 @@ def test_patch_copy() -> None:
             "from": "/test_var_usage/bar",
         }
     )
-
-    # TODO rm
-    print("---- TODO rm ----")
-    # print(parser.get_value("/multi_level/list_3/0")),
-    # print(parser.get_value("/test_var_usage/bar")),
-    print(parser.render())
 
     # Sanity check: validate all modifications
     assert parser.is_modified()

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -900,13 +900,14 @@ def test_patch_remove() -> None:
     assert parser.patch(
         {
             "op": "remove",
-            "path": "/multi_level/list_2/1",
+            "path": "/multi_level/list_2/0",
         }
     )
+    # Ensure comments don't get erased
     assert parser.patch(
         {
             "op": "remove",
-            "path": "/multi_level/list_1/0",
+            "path": "/multi_level/list_1/1",
         }
     )
 
@@ -1018,24 +1019,23 @@ def test_patch_move() -> None:
             "from": "/build/number",
         }
     )
-    assert not parser.is_modified()
-
     # Special failure case: trying to "add" to an illegal path while the
     # "remove" path is still valid
     assert not parser.patch(
         {
             "op": "move",
-            "path": "/build/number",
-            "from": "/build/number/0",
+            "path": "/build/number/0",
+            "from": "/build/number",
         }
     )
     assert not parser.is_modified()
+    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe.yaml")
 
     # Simple move
     assert parser.patch(
         {
             "op": "move",
-            "path": "/requirements",
+            "path": "/requirements/number",
             "from": "/build/number",
         }
     )
@@ -1071,13 +1071,10 @@ def test_patch_move() -> None:
     assert parser.patch(
         {
             "op": "move",
-            "path": "/multi_level",
+            "path": "/multi_level/bar",
             "from": "/test_var_usage/bar",
         }
     )
-
-    # TODO rm
-    print(parser.render())
 
     # Sanity check: validate all modifications
     assert parser.is_modified()

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -140,6 +140,8 @@ def test_contains_value() -> None:
     assert parser.contains_value("/build")
     assert parser.contains_value("/requirements/host/0")
     assert parser.contains_value("/requirements/host/1")
+    # Comments in lists could throw-off array indexing
+    assert parser.contains_value("/multi_level/list_1/1")
     # Path not found cases
     assert not parser.contains_value("/invalid/fake/path")
     assert not parser.is_modified()
@@ -151,7 +153,7 @@ def test_get_value() -> None:
     """
     parser = load_recipe("simple-recipe.yaml")
     # Return a single value
-    assert parser.get_value("/build/number") == {"number": 0}
+    assert parser.get_value("/build/number") == 0
     assert parser.get_value("/build/number/") == 0
     # Return a compound value
     assert parser.get_value("/build") == {
@@ -170,7 +172,7 @@ def test_get_value() -> None:
     assert parser.get_value("/requirements/host/0") == "setuptools"
     assert parser.get_value("/requirements/host/1") == "fakereq"
     # Return a multiline string
-    assert parser.get_value("/about/description") == {"description": SIMPLE_DESCRIPTION}
+    assert parser.get_value("/about/description") == SIMPLE_DESCRIPTION
     assert parser.get_value("/about/description/") == SIMPLE_DESCRIPTION
     # Path not found cases
     with pytest.raises(KeyError):
@@ -178,6 +180,8 @@ def test_get_value() -> None:
     assert parser.get_value("/invalid/fake/path", 42) == 42
     # Tests that a user can pass `None` without throwing
     assert parser.get_value("/invalid/fake/path", None) is None
+    # Comments in lists could throw-off array indexing
+    assert parser.get_value("/multi_level/list_1/1") == "bar"
     assert not parser.is_modified()
 
 
@@ -526,6 +530,121 @@ def test_patch_path_invalid() -> None:
             }
         )
     )
+
+    # move, `path` is invalid
+    assert not (
+        parser.patch(
+            {
+                "op": "move",
+                "path": "/package/path/to/fake/value",
+                "from": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "move",
+                "path": "/build/number/0",
+                "from": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "move",
+                "path": "/multi_level/list2/4",
+                "from": "/about/summary",
+            }
+        )
+    )
+    # move, `from` is invalid
+    assert not (
+        parser.patch(
+            {
+                "op": "move",
+                "from": "/package/path/to/fake/value",
+                "path": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "move",
+                "from": "/build/number/0",
+                "path": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "move",
+                "from": "/multi_level/list2/4",
+                "path": "/about/summary",
+            }
+        )
+    )
+
+    # copy, `path` is invalid
+    assert not (
+        parser.patch(
+            {
+                "op": "copy",
+                "path": "/package/path/to/fake/value",
+                "from": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "copy",
+                "path": "/build/number/0",
+                "from": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "copy",
+                "path": "/multi_level/list2/4",
+                "from": "/about/summary",
+            }
+        )
+    )
+    # copy, `from` is invalid
+    assert not (
+        parser.patch(
+            {
+                "op": "copy",
+                "from": "/package/path/to/fake/value",
+                "path": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "copy",
+                "from": "/build/number/0",
+                "path": "/about/summary",
+            }
+        )
+    )
+    assert not (
+        parser.patch(
+            {
+                "op": "copy",
+                "from": "/multi_level/list2/4",
+                "path": "/about/summary",
+            }
+        )
+    )
+
     # test
     assert not (
         parser.patch(
@@ -718,15 +837,13 @@ def test_patch_add() -> None:
     assert parser.patch(
         {
             "op": "add",
-            "path": "/test_var_usage",
-            "value": {
-                "Stanley": [
-                    "Oh, Joel Miller, you've just found the marble in the oatmeal.",
-                    "You're a lucky, lucky, lucky little boy.",
-                    "'Cause you know why?",
-                    "You get to drink from... the FIRE HOOOOOSE!",
-                ]
-            },
+            "path": "/test_var_usage/Stanley",
+            "value": [
+                "Oh, Joel Miller, you've just found the marble in the oatmeal.",
+                "You're a lucky, lucky, lucky little boy.",
+                "'Cause you know why?",
+                "You get to drink from... the FIRE HOOOOOSE!",
+            ],
         }
     )
 
@@ -741,6 +858,10 @@ def test_patch_add() -> None:
             },
         }
     )
+
+    # Edge case: adding a value to an existing key (non-list) actually replaces
+    # the value at that key, as per the RFC.
+    assert parser.patch({"op": "add", "path": "/about/summary", "value": 62})
 
     # Sanity check: validate all modifications
     assert parser.is_modified()
@@ -882,6 +1003,150 @@ def test_patch_replace() -> None:
     assert parser.is_modified()
     # NOTE: That patches, as of writing, cannot preserve selectors
     assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_replace.yaml")
+
+
+def test_patch_move() -> None:
+    """
+    Tests the `move` patch op.
+    """
+    parser = load_recipe("simple-recipe.yaml")
+    # No-op moves should not corrupt our modification state.
+    assert parser.patch(
+        {
+            "op": "move",
+            "path": "/build/number",
+            "from": "/build/number",
+        }
+    )
+    assert not parser.is_modified()
+
+    # Special failure case: trying to "add" to an illegal path while the
+    # "remove" path is still valid
+    assert not parser.patch(
+        {
+            "op": "move",
+            "path": "/build/number",
+            "from": "/build/number/0",
+        }
+    )
+    assert not parser.is_modified()
+
+    # Simple move
+    assert parser.patch(
+        {
+            "op": "move",
+            "path": "/requirements",
+            "from": "/build/number",
+        }
+    )
+
+    # Moving list item to a new key (replaces existing value)
+    assert parser.patch(
+        {
+            "op": "move",
+            "path": "/build/is_true",
+            "from": "/multi_level/list_3/0",
+        }
+    )
+
+    # Moving list item to a different list
+    assert parser.patch(
+        {
+            "op": "move",
+            "path": "/requirements/host/-",
+            "from": "/multi_level/list_1/1",
+        }
+    )
+
+    # Moving a list entry to another list entry position
+    assert parser.patch(
+        {
+            "op": "move",
+            "path": "/multi_level/list_2/0",
+            "from": "/multi_level/list_2/1",
+        }
+    )
+
+    # Moving a compound type
+    assert parser.patch(
+        {
+            "op": "move",
+            "path": "/multi_level",
+            "from": "/test_var_usage/bar",
+        }
+    )
+
+    # TODO rm
+    print(parser.render())
+
+    # Sanity check: validate all modifications
+    assert parser.is_modified()
+    # NOTE: That patches, as of writing, cannot preserve selectors
+    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_move.yaml")
+
+
+def test_patch_copy() -> None:
+    """
+    Tests the `copy` patch op.
+    """
+    parser = load_recipe("simple-recipe.yaml")
+
+    # Simple copy
+    assert parser.patch(
+        {
+            "op": "copy",
+            "path": "/requirements/number",
+            "from": "/build/number",
+        }
+    )
+
+    # Copying list item to a new key
+    assert parser.patch(
+        {
+            "op": "copy",
+            "path": "/build/is_true",
+            "from": "/multi_level/list_3/0",
+        }
+    )
+
+    # Copying list item to a different list
+    # TODO fix
+    assert parser.patch(
+        {
+            "op": "copy",
+            "path": "/requirements/host/-",
+            "from": "/multi_level/list_1/1",
+        }
+    )
+
+    # Copying a list entry to another list entry position
+    assert parser.patch(
+        {
+            "op": "copy",
+            "path": "/multi_level/list_2/0",
+            "from": "/multi_level/list_2/1",
+        }
+    )
+
+    # Copying a compound type
+    assert parser.patch(
+        {
+            "op": "copy",
+            "path": "/multi_level/bar",
+            "from": "/test_var_usage/bar",
+        }
+    )
+
+    # TODO rm
+    print("---- TODO rm ----")
+    # print(parser.get_value("/multi_level/list_3/0")),
+    # print(parser.get_value("/test_var_usage/bar")),
+    print(parser.render())
+
+    # Sanity check: validate all modifications
+    assert parser.is_modified()
+    # NOTE: That patches, as of writing, cannot preserve selectors
+    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_copy.yaml")
 
 
 ## Diff ##


### PR DESCRIPTION
- Adds `move` and `copy` ops to `patch()`, thus completing all 6 ops defined in the RFC
- Adds unit tests
- Fixes a number of bugs. See comments and commit logs for full details.
- Removes silly nuance around `get_value()`

tl;dr `move` and `copy` are based off of `get_value()`, `add`, and `remove`. Using those functions to develop `move` and `copy` made several edge cases come to light. So what should have been a quick-and-dirty PR turned into a much larger outing.