### PR TITLE
Adds 2 new RecipeParser functions for Anaconda Linter

### DIFF
--- a/percy/render/recipe_parser.py
+++ b/percy/render/recipe_parser.py
@@ -572,7 +572,9 @@ class RecipeParser:
         # this has the unintended consequence of quoting all YAML strings.
         # Although not wrong, it does not follow our common practices.
         # Quote escaping is not required for multiline strings.
-        if not multiline_flag and isinstance(val, str):
+        # We do not escape quotes for Jinja value statements.
+        jinja_re = re.compile(r"{{.*}}")
+        if not multiline_flag and isinstance(val, str) and not jinja_re.match(val):
             if "'" in val or '"' in val:
                 # The PyYaml equivalent function injects newlines, hence why
                 # we abuse the JSON library to write our YAML.

--- a/percy/tests/test_aux_files/multi-output.yaml
+++ b/percy/tests/test_aux_files/multi-output.yaml
@@ -16,6 +16,8 @@ outputs:
         # compilers are to ensure that variants are captured
         - foo3
         - foo2
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
       run:
         - foo
     test:

--- a/percy/tests/test_aux_files/simple-recipe.yaml
+++ b/percy/tests/test_aux_files/simple-recipe.yaml
@@ -17,7 +17,7 @@ requirements:
     - fakereq  # [unix]
   empty_field2:
   run:
-    - python
+    - python  # not a selector
   empty_field3:
 
 about:

--- a/percy/tests/test_aux_files/simple-recipe_test_add_selector.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_add_selector.yaml
@@ -6,21 +6,19 @@ package:
   name: {{ name|lower }}  # [unix]
 
 build:
-  number: 0
-  skip: true  # [py<37]
-  is_true: ls
+  number: 0  # [win]
+  skip: true  # [py<37 or win]
+  is_true: true
 
 requirements:
   empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix]
-    - bar
+    - setuptools  # [win]
+    - fakereq  # [unix and win]
   empty_field2:
   run:
-    - python  # not a selector
-  empty_field3:
-  number: 0
+    - python  # [win] not a selector
+  empty_field3:  # [unix]
 
 about:
   summary: This is a small recipe for testing
@@ -32,24 +30,17 @@ about:
 
 multi_level:
   list_1:
-    - foo
+    - foo  # [unix]
     # Ensure a comment in a list is supported
     - bar
   list_2:
-    - bat
     - cat
-    - bat
+    - bat  # [win]
     - mat
   list_3:
     - ls
     - sl
     - cowsay
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
 
 test_var_usage:
   foo: {{ version }}

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
@@ -19,7 +19,7 @@ requirements:
     - fakereq  # [unix]
   empty_field2: Not so empty now
   run:
-    - python
+    - python  # not a selector
   empty_field3:
 
 about:

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
@@ -17,7 +17,7 @@ requirements:
     - bar
   empty_field2:
   run:
-    - python
+    - python  # not a selector
   empty_field3:
   number: 0
 

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
@@ -14,7 +14,7 @@ requirements:
     - setuptools  # [unix]
     - fakereq  # [unix]
   run:
-    - python
+    - python  # not a selector
   empty_field3:
 
 multi_level:


### PR DESCRIPTION
- Adds a `find_value()` function to find values in the parse tree
- Adds a `add_selector()` function to allow callers to modify recipe selectors
- Adds unit tests

Both of these new functions are being added to automatically fix the `no_git_on_windows` Anaconda Linter rule.