### PR TITLE
Adds support for removing selectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test-debug:		## runs test cases with debugging info enabled
 	$(PYTHON3) -m pytest -vv --capture=no percy/tests/
 
 test-cov:		## checks test coverage requirements
-	$(PYTHON3) -m pytest --cov-config=.coveragerc --cov=percy percy/tests/ --cov-fail-under=10 --cov-report term-missing
+	$(PYTHON3) -m pytest --cov-config=.coveragerc --cov=percy percy/tests/ --cov-fail-under=17 --cov-report term-missing
 
 lint:			## runs the linter against the project
 	pylint --rcfile=.pylintrc $(LINTER_FILES)

--- a/percy/tests/test_aux_files/simple-recipe.yaml
+++ b/percy/tests/test_aux_files/simple-recipe.yaml
@@ -16,7 +16,7 @@ requirements:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix] selector with comment
-  empty_field2:
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
   run:
     - python  # not a selector
   empty_field3:

--- a/percy/tests/test_aux_files/simple-recipe.yaml
+++ b/percy/tests/test_aux_files/simple-recipe.yaml
@@ -15,7 +15,7 @@ requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
-    - fakereq  # [unix]
+    - fakereq  # [unix] selector with comment
   empty_field2:
   run:
     - python  # not a selector

--- a/percy/tests/test_aux_files/simple-recipe_test_add_selector.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_add_selector.yaml
@@ -16,7 +16,7 @@ requirements:
   host:
     - setuptools  # [win]
     - fakereq  # [unix and win]
-  empty_field2:
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
   run:
     - python  # [win] not a selector
   empty_field3:  # [unix]

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
@@ -17,7 +17,7 @@ requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
-    - fakereq  # [unix]
+    - fakereq  # [unix] selector with comment
   empty_field2: Not so empty now
   run:
     - python  # not a selector

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_copy.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_copy.yaml
@@ -17,7 +17,7 @@ requirements:
     - setuptools  # [unix]
     - fakereq  # [unix] selector with comment
     - bar
-  empty_field2:
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
   run:
     - python  # not a selector
   empty_field3:

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
@@ -14,7 +14,7 @@ requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
-    - fakereq  # [unix]
+    - fakereq  # [unix] selector with comment
     - bar
   empty_field2:
   run:

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_move.yaml
@@ -16,7 +16,7 @@ requirements:
     - setuptools  # [unix]
     - fakereq  # [unix] selector with comment
     - bar
-  empty_field2:
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
   run:
     - python  # not a selector
   empty_field3:

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_remove.yaml
@@ -13,7 +13,7 @@ requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
-    - fakereq  # [unix]
+    - fakereq  # [unix] selector with comment
   run:
     - python  # not a selector
   empty_field3:

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
@@ -15,7 +15,7 @@ requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
-    - fakereq  # [unix]
+    - fakereq  # [unix] selector with comment
   empty_field2:
   run:
     - cpython

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
@@ -16,7 +16,7 @@ requirements:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix] selector with comment
-  empty_field2:
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
   run:
     - cpython
   empty_field3:

--- a/percy/tests/test_aux_files/simple-recipe_test_remove_selector.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_remove_selector.yaml
@@ -3,25 +3,23 @@
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
 
 build:
   number: 0
   skip: true  # [py<37]
-  is_true: ls
+  is_true: true
 
 # Comment above a top-level structure
 requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-    - bar
+    - fakereq  # selector with comment
   empty_field2:
   run:
     - python  # not a selector
   empty_field3:
-  number: 0
 
 about:
   summary: This is a small recipe for testing
@@ -37,7 +35,6 @@ multi_level:
     # Ensure a comment in a list is supported
     - bar
   list_2:
-    - bat
     - cat
     - bat
     - mat
@@ -45,12 +42,6 @@ multi_level:
     - ls
     - sl
     - cowsay
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
 
 test_var_usage:
   foo: {{ version }}

--- a/percy/tests/test_aux_files/simple-recipe_test_remove_selector.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_remove_selector.yaml
@@ -16,7 +16,7 @@ requirements:
   host:
     - setuptools  # [unix]
     - fakereq  # selector with comment
-  empty_field2:
+  empty_field2:  # selector with comment with comment symbol
   run:
     - python  # not a selector
   empty_field3:

--- a/percy/tests/test_aux_files/simple-recipe_test_search_and_patch.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_search_and_patch.yaml
@@ -15,7 +15,7 @@ requirements:
   empty_field1:
   host:
     - setuptools  # [unix]
-    - fakereq  # [unix]
+    - fakereq  # [unix] selector with comment
   empty_field2:
   run:
     - conda

--- a/percy/tests/test_aux_files/simple-recipe_test_search_and_patch.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_search_and_patch.yaml
@@ -16,7 +16,7 @@ requirements:
   host:
     - setuptools  # [unix]
     - fakereq  # [unix] selector with comment
-  empty_field2:
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
   run:
     - conda
   empty_field3:

--- a/percy/tests/test_aux_files/simple-recipe_to_str.out
+++ b/percy/tests/test_aux_files/simple-recipe_to_str.out
@@ -15,6 +15,8 @@ RecipeParser Instance
   [py<37]
     - skip -> /build/skip
     - True -> /build/skip
+  [unix and win]
+    - empty_field2 -> /requirements/empty_field2
 - is_modified?: False
 - Tree:
 /

--- a/percy/tests/test_aux_files/simple-recipe_to_str.out
+++ b/percy/tests/test_aux_files/simple-recipe_to_str.out
@@ -1,0 +1,70 @@
+--------------------
+RecipeParser Instance
+- Variables Table:
+{
+  "zz_non_alpha_first": 42,
+  "name": "types-toml",
+  "version": "0.10.8.6"
+}
+- Selectors Table:
+  [unix]
+    - name -> /package/name
+    - {{ name|lower }} -> /package/name
+    - setuptools -> /requirements/host/0
+    - fakereq -> /requirements/host/1
+  [py<37]
+    - skip -> /build/skip
+    - True -> /build/skip
+- is_modified?: False
+- Tree:
+/
+  |- package
+    |- name
+      |- {{ name|lower }}
+  |- build
+    |- number
+      |- 0
+    |- skip
+      |- True
+    |- is_true
+      |- True
+  |- <Comment: # Comment above a top-level structure>
+  |- requirements
+    |- empty_field1
+    |- host
+      |- setuptools
+      |- fakereq
+    |- empty_field2
+    |- run
+      |- python
+    |- empty_field3
+  |- about
+    |- summary
+      |- This is a small recipe for testing
+    |- description
+      |- ["This is a PEP '561 type stub package for the toml package.", 'It can be used by type-checking tools like mypy, pyright,', 'pytype, PyCharm, etc. to check code that uses toml.']
+    |- license
+      |- Apache-2.0 AND MIT
+  |- multi_level
+    |- list_1
+      |- foo
+      |- <Comment: # Ensure a comment in a list is supported>
+      |- bar
+    |- list_2
+      |- cat
+      |- bat
+      |- mat
+    |- list_3
+      |- ls
+      |- sl
+      |- cowsay
+  |- test_var_usage
+    |- foo
+      |- {{ version }}
+    |- bar
+      |- baz
+      |- {{ zz_non_alpha_first }}
+      |- blah
+      |- This {{ name }} is silly
+      |- last
+--------------------

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -63,6 +63,32 @@ def test_construction() -> None:
     # assert parser._root == TODO
 
 
+def test_str() -> None:
+    """
+    Tests string casting
+    """
+    parser = load_recipe("simple-recipe.yaml")
+    assert str(parser) == load_file(f"{TEST_FILES_PATH}/simple-recipe_to_str.out")
+    # Regression test: Run a function a second time to ensure that `SelectorInfo::__str__()` doesn't accidentally purge
+    # the underlying stack when the string is being rendered.
+    assert str(parser) == load_file(f"{TEST_FILES_PATH}/simple-recipe_to_str.out")
+    assert not parser.is_modified()
+
+
+def test_eq() -> None:
+    """
+    Tests equivalency function
+    """
+    parser0 = load_recipe("simple-recipe.yaml")
+    parser1 = load_recipe("simple-recipe.yaml")
+    parser2 = load_recipe("types-toml.yaml")
+    assert parser0 == parser1
+    assert parser0 != parser2
+    assert not parser0.is_modified()
+    assert not parser1.is_modified()
+    assert not parser2.is_modified()
+
+
 def test_dog_food_easy() -> None:
     """
     Test "eating our own dog food": Take a recipe, construct a parser, re-render

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -460,6 +460,37 @@ def test_add_selector() -> None:
     assert parser.is_modified()
 
 
+def test_remove_selector() -> None:
+    """
+    Tests removing a selector to a recipe
+    """
+    parser = load_recipe("simple-recipe.yaml")
+    # Test that selector validation is working
+    with pytest.raises(KeyError):
+        parser.remove_selector("/package/path/to/fake/value")
+
+    # Don't fail when a selector doesn't exist on a line
+    parser.remove_selector("/build/number")
+    # Don't remove a non-selector comment
+    parser.remove_selector("/requirements/run/0")
+    assert not parser.is_modified()
+
+    # Remove a selector
+    parser.remove_selector("/package/name")
+    assert parser.get_selector_paths("[unix]") == [
+        "/requirements/host/0",
+        "/requirements/host/1",
+    ]
+    # Remove a selector with a comment
+    parser.remove_selector("/requirements/host/1")
+    assert parser.get_selector_paths("[unix]") == [
+        "/requirements/host/0",
+    ]
+
+    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_remove_selector.yaml")
+    assert parser.is_modified()
+
+
 ## Patch and Search ##
 
 


### PR DESCRIPTION
- `remove_selectors()` allows for the removal of selectors on a parse tree path
- The function preserves non-selector comments
- Adds unit tests
- Adds some unrelated unit testing around `__eq__()` and `__str__()` functions that got missed.