### PR TITLE
Fixes `render_to_object()` for multi-output recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ export PRINT_HELP_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 # For now, most tools only run on new files, not the entire project.
-LINTER_FILES := percy/parser/*.py
+LINTER_FILES := percy/parser/*.py scripts/*.py
 
 clean: clean-cov clean-build clean-env clean-pyc clean-test clean-other ## remove all build, test, coverage and Python artifacts
 

--- a/percy/parser/_types.py
+++ b/percy/parser/_types.py
@@ -49,7 +49,7 @@ class Regex:
     """
 
     # Pattern to detect Jinja variable names and functions
-    _JINJA_VAR_FUNCTION_PATTERN: Final[str] = r"[a-zA-Z_][a-zA-Z0-9_\|\'\(\)]*"
+    _JINJA_VAR_FUNCTION_PATTERN: Final[str] = r"[a-zA-Z_][a-zA-Z0-9_\|\'\"\(\)\, =\.\-]*"
 
     # Jinja regular expressions
     JINJA_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -322,8 +322,9 @@ class RecipeParser:
                 multiline = lines[line_idx]
                 multiline_indent = num_tab_spaces(multiline)
                 # Add the line to the list once it is verified to be the next line to capture in this node. This means
-                # that `line_idx` will point to the line of the next node, post-processing.
-                while multiline_indent > new_indent:
+                # that `line_idx` will point to the line of the next node, post-processing. Note that blank lines are
+                # valid in multi-line strings, occasionally found in `/about/summary` sections.
+                while multiline_indent > new_indent or multiline == "":
                     multiline_node.value.append(multiline.strip())
                     line_idx += 1
                     multiline = lines[line_idx]

--- a/percy/tests/test_aux_files/huggingface_hub.yaml
+++ b/percy/tests/test_aux_files/huggingface_hub.yaml
@@ -1,0 +1,72 @@
+{% set name = "huggingface_hub" %}
+{% set version = "0.15.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a61b7d1a7769fe10119e730277c72ab99d95c48d86a3d6da3e9f3d0f632a4081
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  entry_points:
+    - huggingface-cli=huggingface_hub.commands.huggingface_cli:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - filelock
+    - fsspec
+    - importlib-metadata  # [py<38]
+    - packaging >=20.9
+    - pyyaml >=5.1
+    - requests
+    - tqdm >=4.42.1
+    - typing-extensions >=3.7.4.3
+  run_constrained:
+    - fastai >=2.4
+    - fastcore >=1.3.27
+    - InquirerPy ==0.3.4
+
+test:
+  imports:
+    - huggingface_hub
+    - huggingface_hub.commands
+  requires:
+    - pip
+  commands:
+    - pip check
+    - huggingface-cli --help
+
+about:
+  home: https://github.com/huggingface/huggingface_hub
+  summary: Client library to download and publish models, datasets and other repos on the huggingface.co hub
+  description: |
+    The huggingface_hub is a client library to interact with the Hugging Face Hub. The Hugging Face Hub is a platform with over 35K models, 4K datasets, and 2K demos in which people can easily collaborate in their ML workflows. The Hub works as a central place where anyone can share, explore, discover, and experiment with open-source Machine Learning.
+
+    With huggingface_hub, you can easily download and upload models, datasets, and Spaces. You can extract useful information from the Hub, and do much more. Some example use cases:
+
+    - Downloading and caching files from a Hub repository.
+    - Creating repositories and uploading an updated model every few epochs.
+    - Extract metadata from all models that match certain criteria (e.g. models for text-classification).
+    - List all files from a specific repository.
+  license: Apache-2.0
+  license_file: LICENSE
+  license_family: Apache
+  doc_url: https://huggingface.co/docs/hub/index
+  dev_url: https://github.com/huggingface/huggingface_hub
+
+extra:
+  recipe-maintainers:
+    - BastianZim
+  skip-lints:
+    - python_build_tool_in_run

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -131,6 +131,17 @@ def test_dog_food_multi_output() -> None:
     assert parser.render() == multi
 
 
+def test_dog_food_blank_lines_in_multiline() -> None:
+    """
+    Test "eating our own dog food": Take a recipe, construct a parser, re-render and ensure the output matches the input
+
+    This tests recipes that contain extra blank lines in their multiline strings.
+    """
+    blank_lines = load_file(f"{TEST_FILES_PATH}/huggingface_hub.yaml")
+    parser = RecipeParser(blank_lines)
+    assert parser.render() == blank_lines
+
+
 def test_render_to_object() -> None:
     """
     Tests rendering a recipe to an object format.

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -167,6 +167,78 @@ def test_render_to_object() -> None:
             "list_1": ["foo", "bar"],
         },
     }
+    # Tests variable substitution mode
+    assert parser.render_to_object(True) == {
+        "about": {
+            "description": SIMPLE_DESCRIPTION,
+            "license": "Apache-2.0 AND MIT",
+            "summary": "This is a small recipe for testing",
+        },
+        "test_var_usage": {
+            "foo": "0.10.8.6",
+            "bar": [
+                "baz",
+                42,
+                "blah",
+                "This types-toml is silly",
+                "last",
+            ],
+        },
+        "build": {"is_true": True, "skip": True, "number": 0},
+        "package": {"name": "types-toml"},
+        "requirements": {
+            "empty_field1": None,
+            "host": ["setuptools", "fakereq"],
+            "empty_field2": None,
+            "run": ["python"],
+            "empty_field3": None,
+        },
+        "multi_level": {
+            "list_3": ["ls", "sl", "cowsay"],
+            "list_2": ["cat", "bat", "mat"],
+            "list_1": ["foo", "bar"],
+        },
+    }
+
+
+def test_render_to_object_multi_output() -> None:
+    """
+    Tests rendering a recipe to an object format.
+    """
+    parser = load_recipe("multi-output.yaml")
+    assert parser.render_to_object() == {
+        "outputs": [
+            {
+                "name": "libdb",
+                "build": {
+                    "run_exports": ["bar"],
+                },
+                "test": {
+                    "commands": [
+                        "test -f ${PREFIX}/lib/libdb${SHLIB_EXT}",
+                        r"if not exist %LIBRARY_BIN%\libdb%SHLIB_EXT%",
+                    ],
+                },
+            },
+            {
+                "name": "db",
+                "requirements": {
+                    "build": [
+                        "foo3",
+                        "foo2",
+                        "{{ compiler('c') }}",
+                        "{{ compiler('cxx') }}",
+                    ],
+                    "run": ["foo"],
+                },
+                "test": {
+                    "commands": [
+                        "db_archive -m hello",
+                    ]
+                },
+            },
+        ]
+    }
 
 
 ## Values ##

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Scripts
+
+This directory contains utility scripts used by `percy` developers.
+
+These are not meant to be published for general consumption or used with the `percy <command>` interface.
+
+**NOTE:** There is no `__init__.py` in this folder and it is contained in the top-level. These scripts are not meant
+meant to be used in other parts of the project.

--- a/scripts/analyze_aggregate_errors.py
+++ b/scripts/analyze_aggregate_errors.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+File:           analyze_aggregate_errors.py
+Description:    Utility script that reads-in the output from `percy aggregate` and gathers statistics on error messages.
+                This is useful for debugging recipe parsing issues.
+
+                To generate the file, run:
+                    percy aggregate order -r RENDERER &> file
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def main():
+    """
+    Primary execution point of the script.
+    """
+    if len(sys.argv) != 2:
+        print("usage: analyze_aggregate_errors.py file")
+        sys.exit(1)
+
+    error_re = re.compile(r"^(ERROR:root:Render issue )(.*-feedstock)( : )(.*)$")
+    feedstocks = {}
+    hist = {}
+    error_cntr = 0
+
+    with open(sys.argv[1], encoding="utf-8") as file:
+        for line in file:
+            match = error_re.match(line)
+            if match is not None:
+                error_cntr += 1
+                error = match.group(4)
+                feedstock = match.group(2)
+                if error not in hist:
+                    hist[error] = 1
+                    feedstocks[error] = [feedstock]
+                else:
+                    hist[error] += 1
+                    feedstocks[error].append(feedstock)
+
+    print("==== Feedstock-Breakdown ====")
+    print(json.dumps(feedstocks, indent=2, sort_keys=True))
+    print("==== Histogram ====")
+    print(json.dumps(hist, indent=2, sort_keys=True))
+    print("==== Stats ====")
+    print(f"Total error count: {error_cntr}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Function now handles rendering multi-output recipes. This is accomplished by handling Collection Nodes as a special case. - This code isn't perfectly recursive, but it gets the current job done. - This fixes 105 previously unparsed recipes
- Modifies an existing regex to dramatically boost recipe compatibility
- Adds unit tests
- Adds `script/` directory - This directory contains tools for developers that should not be broadly published - Adds `analyze_aggregate_errors.py` script to help identify the biggest sources of recipe parsing errors.

Here are the current error counts from `aggregate`, courtesy of the new script:
```
==== Histogram ====
{
  "'cli_opts'": 1,
  "'dict' object has no attribute 'append'": 8,
  "'int' object does not support item assignment": 1,
  "'outputs'": 1,
  "'requirements'": 1,
  "'str' object does not support item assignment": 11,
  "'str' object has no attribute 'append'": 2,
  "(PosixPath('/Users/smartin/work/aggregate/clangdev-feedstock/recipe'), 'can only concatenate str (not \"int\") to str')": 1,
  "(PosixPath('/Users/smartin/work/aggregate/gtk3-feedstock/recipe'), \"unexpected char '#' at 4499 (at line 133)\")": 1,
  "(PosixPath('/Users/smartin/work/aggregate/theano-feedstock/recipe'), \"render.<locals>.<lambda>() got multiple values for argument 'max_pin'\")": 1,
  "expected '<document start>', but found '<scalar>'": 2,
  "found undefined alias 'test'": 1,
  "list index out of range": 54,
  "list indices must be integers or slices, not object": 1,
  "list indices must be integers or slices, not str": 4,
  "mapping values are not allowed here": 1,
  "pop from empty list": 11,
  "string indices must be integers, not 'str'": 1,
  "while constructing a mapping": 11,
  "while parsing a block collection": 1,
  "while parsing a block mapping": 3,
  "while parsing a flow mapping": 12,
  "while scanning a block scalar": 1,
  "while scanning a quoted scalar": 4,
  "while scanning an alias": 4,
  "while scanning an anchor": 1,
  "while scanning for the next token": 54
}
==== Stats ====
Total error count: 194
```