### PR TITLE
v0.1.1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
 [run]
 omit =
     percy/tests/*
-    */__init__.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+Note: version releases in the 0.x.y range may introduce breaking changes.
+
+## 0.1.1
+- Adds `CHANGELOG.md`
+- Bug fixes
+- README updates

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Here is a rough outline of how to conduct a release of this project:
 1. Update the version number in `pyproject.toml`
 1. Ensure `environment.yaml` is up to date with the latest dependencies
 1. Create a new release on GitHub with a version tag.
-1. The Anaconda packaging team will need to update and publish
+1. The Anaconda packaging team will need to update
 [the feedstock](https://github.com/AnacondaRecipes/percy-feedstock)
-to [aggregate](https://github.com/AnacondaRecipes/aggregate).
+and [aggregate](https://github.com/AnacondaRecipes/aggregate) and publish to `distro-tooling`
 
 ## Other examples
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make environment
 conda activate percy
 ```
 
-# Developer Installation
+# Developer Notes
 ```sh
 make dev
 conda activate percy
@@ -115,6 +115,16 @@ A group name corresponds to the github/gitlab... organization name, extracted fr
 
         percy aggregate outdated --help
         percy aggregate outdated
+
+## Release process
+Here is a rough outline of how to conduct a release of this project:
+1. Update `CHANGELOG.md`
+1. Update the version number in `pyproject.toml`
+1. Ensure `environment.yaml` is up to date with the latest dependencies
+1. Create a new release on GitHub with a version tag.
+1. The Anaconda packaging team will need to update and publish
+[the feedstock](https://github.com/AnacondaRecipes/percy-feedstock)
+to [aggregate](https://github.com/AnacondaRecipes/aggregate).
 
 ## Other examples
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,6 @@
 name: percy
+channels:
+  - defaults
 
 dependencies:
   - black
@@ -10,7 +12,7 @@ dependencies:
   - pytest-xdist
   - pylint
   - pip
-  - conda-forge::click>=8.1.6
+  - click>=8.1.6
   - conda
   - jinja2
   - pyyaml


### PR DESCRIPTION
- Version number was already set
- Adds a `CHANGELOG.md`
- README updates
- Explicitly states to use packages from `defaults`, as `percy` will be moving to `distro-tooling`