### PR TITLE
Converts docstring format

### DIFF
--- a/.docconvert.json
+++ b/.docconvert.json
@@ -1,0 +1,19 @@
+{
+    "input_style": "guess",
+    "output_style": "rest",
+    "accepted_shebangs": [
+        "python"
+    ],
+    "output": {
+        "first_line": false,
+        "replace_quotes": "\"\"\"",
+        "standard_indent": "    ",
+        "tab_length": 4,
+        "realign": true,
+        "max_line_length": 120,
+        "use_optional": false,
+        "remove_type_back_ticks": "true",
+        "use_types": false,
+        "separate_keywords": false
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CONDA_ACTIVATE = source $$(conda info --base)/etc/profile.d/conda.sh ; conda act
 # Ensure that we are using the python interpretter provided by the conda environment.
 PYTHON3 := "$(CONDA_PREFIX)/bin/python3"
 
-.PHONY: clean clean-env clean-test clean-pyc clean-build clean-other help dev test test-debug test-cov pre-commit lint format analyze
+.PHONY: clean clean-env clean-test clean-pyc clean-build clean-other help dev test test-debug test-cov pre-commit lint format format-docs analyze
 .DEFAULT_GOAL := help
 
 CONDA_ENV_NAME ?= percy
@@ -106,6 +106,9 @@ lint:			## runs the linter against the project
 format:			## runs the code auto-formatter
 	isort --profile black --line-length=120 percy
 	black --line-length=120 percy
+
+format-docs:	## runs the docstring auto-formatter. Note this requires manually installing `docconvert`
+	docconvert --in-place --config .docconvert.json percy
 
 analyze:		## runs static analyzer on the project
 	mypy --config-file=.mypy.ini $(LINTER_FILES)

--- a/Makefile
+++ b/Makefile
@@ -111,4 +111,4 @@ format-docs:	## runs the docstring auto-formatter. Note this requires manually i
 	docconvert --in-place --config .docconvert.json percy
 
 analyze:		## runs static analyzer on the project
-	mypy --config-file=.mypy.ini $(LINTER_FILES)
+	mypy --config-file=.mypy.ini --cache-dir=/dev/null $(LINTER_FILES)

--- a/percy/commands/aggregate.py
+++ b/percy/commands/aggregate.py
@@ -17,6 +17,7 @@ import yaml
 import percy.render.aggregate
 import percy.render.recipe
 import percy.repodata.repodata
+from percy.render._renderer import RendererType
 
 
 def get_configured_aggregate(cmd_line: Optional[str | Path] = None) -> Path:
@@ -46,7 +47,7 @@ def get_configured_aggregate(cmd_line: Optional[str | Path] = None) -> Path:
 
 
 def load_aggregate(
-    obj: Any, subdir: str, python: str, others: dict[str, str], renderer: percy.render.recipe.RendererType
+    obj: Any, subdir: str, python: str, others: dict[str, str], renderer: RendererType
 ) -> percy.render.aggregate.Aggregate:
     """
     Reads aggregate from disk and constructs an object.
@@ -80,7 +81,7 @@ def print_build_order(buildout: dict[str, percy.render.aggregate.Feedstock]) -> 
             print(f"{i:03} {feedstock.name:30} {list(feedstock.packages.keys())}")
 
 
-def sanitize_renderer_enum(_0, _1, value: str) -> percy.render.recipe.RendererType:  # pylint: disable=invalid-name
+def sanitize_renderer_enum(_0, _1, value: str) -> RendererType:  # pylint: disable=invalid-name
     """
     Takes the renderer type as a user provided string and converts it to the
     enum form.
@@ -88,7 +89,7 @@ def sanitize_renderer_enum(_0, _1, value: str) -> percy.render.recipe.RendererTy
     :returns: Enumerated version o the parser
     """
     # Access should be safe as `click` handles the input limitations for us.
-    return percy.render.recipe.RendererType[value.upper()]
+    return RendererType[value.upper()]
 
 
 def base_options(f: Callable):

--- a/percy/commands/aggregate.py
+++ b/percy/commands/aggregate.py
@@ -22,8 +22,8 @@ import percy.repodata.repodata
 def get_configured_aggregate(cmd_line: Optional[str | Path] = None) -> Path:
     """
     Determines the path of the aggregate repoistory
-    :param cmd_line:    (Optional) If specified, this is the path to a recipe file to operate on. If not specified, the
-                        recipe file is determined by the current working directory.
+    :param cmd_line: (Optional) If specified, this is the path to a recipe file to operate on. If not specified, the
+        recipe file is determined by the current working directory.
     """
     # command line has highest precedence
     if cmd_line:
@@ -50,12 +50,12 @@ def load_aggregate(
 ) -> percy.render.aggregate.Aggregate:
     """
     Reads aggregate from disk and constructs an object.
-    :param obj:         User object, provided by Click
-    :param subdir:      Target architecture
-    :param python:      Target Python version
-    :param others:      Additional key-value pairs to use
-    :param renderer:    Rendering engine to use for parsing YAML
-    :return: The aggregate repository, represented as a class instance
+    :param obj: User object, provided by Click
+    :param subdir: Target architecture
+    :param python: Target Python version
+    :param others: Additional key-value pairs to use
+    :param renderer: Rendering engine to use for parsing YAML
+    :returns: The aggregate repository, represented as a class instance
     """
     print(f"Renderer in use: {renderer.name}")
     aggregate_path = obj["aggregate_directory"]
@@ -72,7 +72,7 @@ def load_aggregate(
 def print_build_order(buildout: dict[str, percy.render.aggregate.Feedstock]) -> None:
     """
     Prints the build order
-    :param buildout:    Dictionary representing the build ordering
+    :param buildout: Dictionary representing the build ordering
     """
     stages = [list(result) for key, result in groupby(buildout, key=lambda f: f.weight)]
     for i, stage in enumerate(stages):
@@ -84,8 +84,8 @@ def sanitize_renderer_enum(_0, _1, value: str) -> percy.render.recipe.RendererTy
     """
     Takes the renderer type as a user provided string and converts it to the
     enum form.
-    :param value:   User-provided string to parse
-    :return: Enumerated version o the parser
+    :param value: User-provided string to parse
+    :returns: Enumerated version o the parser
     """
     # Access should be safe as `click` handles the input limitations for us.
     return percy.render.recipe.RendererType[value.upper()]
@@ -94,7 +94,7 @@ def sanitize_renderer_enum(_0, _1, value: str) -> percy.render.recipe.RendererTy
 def base_options(f: Callable):
     """
     Base options/flags supported by this command
-    :param f:   Function callback
+    :param f: Function callback
     """
 
     @click.option(
@@ -142,7 +142,7 @@ def base_options(f: Callable):
 def order_options(f: Callable):
     """
     Ordering options/flags supported by this command
-    :param f:   Function callback
+    :param f: Function callback
     """
 
     @click.option(
@@ -201,7 +201,8 @@ def order_options(f: Callable):
 )
 @click.pass_context
 def aggregate(ctx, aggregate):  # pylint: disable=redefined-outer-name
-    """Commands that operate on aggregates.
+    """
+    Commands that operate on aggregates.
 
     An aggregate is a collection of recipes.
 
@@ -250,7 +251,9 @@ def downstream(
     drop_noarch,
     sections,
 ):
-    """Prints build order of feedstock downstream dependencies"""
+    """
+    Prints build order of feedstock downstream dependencies
+    """
 
     # load aggregate
     aggregate_repo = load_aggregate(obj, subdir, python, others, renderer)
@@ -292,7 +295,9 @@ def upstream(
     drop_noarch,
     sections,  # pylint: disable=unused-argument
 ):
-    """Prints build order of feedstock upstream dependencies"""
+    """
+    Prints build order of feedstock upstream dependencies
+    """
 
     # load aggregate
     aggregate_repo = load_aggregate(obj, subdir, python, others, renderer)
@@ -330,7 +335,9 @@ def order(
     drop_noarch,
     sections,
 ):
-    """Prints build order of specified feedstocks"""
+    """
+    Prints build order of specified feedstocks
+    """
 
     # load aggregate
     aggregate_repo = load_aggregate(obj, subdir, python, others, renderer)
@@ -376,7 +383,9 @@ def order(
     help="Identify packages from aggregate not on defaults",
 )
 def outdated(obj, subdir, python, others, renderer, missing_local, missing_defaults):
-    """Prints outdated with defaults"""
+    """
+    Prints outdated with defaults
+    """
 
     results = {}
 

--- a/percy/commands/main.py
+++ b/percy/commands/main.py
@@ -25,7 +25,8 @@ cli.add_command(aggregate)
 
 @cli.command()
 def tabcompletion():
-    """Print out shell commands for setting up shell completion.
+    """
+    Print out shell commands for setting up shell completion.
 
     For local shell use:
         eval "`percy tabcompletion`"

--- a/percy/commands/recipe.py
+++ b/percy/commands/recipe.py
@@ -21,9 +21,9 @@ import percy.render.recipe
 def get_recipe(cmd_line: Optional[str | Path] = None) -> Path:
     """
     Determine the path to the target recipe file
-    :param cmd_line:    (Optional) If specified, this is the path to a recipe file to operate on. If not specified, the
-                        recipe file is determined by the current working directory.
-    :return: Path to the recipe file of interest
+    :param cmd_line: (Optional) If specified, this is the path to a recipe file to operate on. If not specified, the
+        recipe file is determined by the current working directory.
+    :returns: Path to the recipe file of interest
     """
     # command line has highest precedence
     if cmd_line:
@@ -42,7 +42,7 @@ def get_recipe(cmd_line: Optional[str | Path] = None) -> Path:
 def base_options(f: Callable):
     """
     Base options/flags supported by this command
-    :param f:   Function callback
+    :param f: Function callback
     """
 
     @click.option(
@@ -98,7 +98,9 @@ def base_options(f: Callable):
 @click.option("--recipe", "-r", metavar="FILE", help="Recipe meta.yaml to operate on.")
 @click.pass_context
 def recipe(ctx, recipe: str):  # pylint: disable=redefined-outer-name
-    """Commands that operate on a recipe."""
+    """
+    Commands that operate on a recipe.
+    """
     ctx.ensure_object(dict)
     ctx.obj["recipe_path"] = Path(get_recipe(recipe))
 
@@ -107,7 +109,9 @@ def recipe(ctx, recipe: str):  # pylint: disable=redefined-outer-name
 @click.pass_obj
 @base_options
 def render(obj, subdir, python, others, backend):
-    """Render a recipe."""
+    """
+    Render a recipe.
+    """
 
     # render recipe
     recipe_path = obj["recipe_path"]
@@ -128,7 +132,9 @@ def render(obj, subdir, python, others, backend):
 @click.pass_obj
 @base_options
 def outdated(obj, subdir, python, others, backend):
-    """Render a recipe."""
+    """
+    Render a recipe.
+    """
 
     # render recipe
     recipe_path = obj["recipe_path"]
@@ -179,7 +185,8 @@ def outdated(obj, subdir, python, others, backend):
 )
 @click.argument("patch_file", metavar="FILE")
 def patch(obj, subdir, python, others, backend, increment_build_number: bool, parse_tree: bool, patch_file):
-    """Patch a recipe. Takes a patch file as input, with content like:
+    """
+    Patch a recipe. Takes a patch file as input, with content like:
 
     \b
     [

--- a/percy/commands/recipe.py
+++ b/percy/commands/recipe.py
@@ -14,6 +14,7 @@ import click
 
 import percy.commands.aggregate
 import percy.render.recipe
+from percy.render._renderer import RendererType
 
 # pylint: disable=line-too-long
 
@@ -50,7 +51,7 @@ def base_options(f: Callable):
         "-b",
         callback=percy.commands.aggregate.sanitize_renderer_enum,
         type=click.Choice(
-            [e.name for e in percy.render.recipe.renderer.RendererType],
+            [e.name for e in RendererType],
             case_sensitive=False,
         ),
         default="PYYAML",
@@ -211,7 +212,7 @@ def patch(obj, subdir, python, others, backend, increment_build_number: bool, pa
     recipe: percy.render.recipe.Recipe  # pylint: disable=redefined-outer-name
     # Enables parse-tree mode
     if parse_tree:
-        backend = percy.render.recipe.RendererType.PERCY
+        backend = RendererType.PERCY
         op_mode = percy.render.recipe.OpMode.PARSE_TREE
         recipe = percy.render.recipe.Recipe.from_file(
             recipe_path,

--- a/percy/examples/aggregate_deps_issue_finder/aggregate_deps_issue_finder.py
+++ b/percy/examples/aggregate_deps_issue_finder/aggregate_deps_issue_finder.py
@@ -1,4 +1,5 @@
-""" Script to find issues in aggregate pinned feedstocks.
+"""
+Script to find issues in aggregate pinned feedstocks.
 """
 
 import argparse

--- a/percy/examples/blts/gen_blts_build_order.py
+++ b/percy/examples/blts/gen_blts_build_order.py
@@ -1,4 +1,5 @@
-""" Generate build scripts to build all packages depending on python.
+"""
+Generate build scripts to build all packages depending on python.
 """
 
 import os

--- a/percy/examples/build_order_to_jira.py
+++ b/percy/examples/build_order_to_jira.py
@@ -1,5 +1,6 @@
-""" Find what to rebuild when updating a feedstock.
-    Create corresponding tickets in Jira.
+"""
+Find what to rebuild when updating a feedstock.
+   Create corresponding tickets in Jira.
 """
 
 import argparse

--- a/percy/examples/patch/updater.py
+++ b/percy/examples/patch/updater.py
@@ -1,4 +1,5 @@
-""" Update a recipe
+"""
+Update a recipe
 """
 
 import argparse

--- a/percy/examples/patch/updater.py
+++ b/percy/examples/patch/updater.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 
 import percy.render.recipe as recipe
+from percy.render._renderer import RendererType
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -46,7 +47,7 @@ def load_recipe(recipe_path):
         ["3.10"],
         others,
         False,
-        recipe.RendererType.RUAMEL,
+        RendererType.RUAMEL,
     )
     rendered_recipe = next(iter(rendered_recipes))
     return rendered_recipe

--- a/percy/examples/patch/updater_standalone.py
+++ b/percy/examples/patch/updater_standalone.py
@@ -74,8 +74,7 @@ class Recipe:
         """
         Has recipe been modified.
 
-        Returns:
-            bool: True if recipe has been modified.
+        :returns: True if recipe has been modified.
         """
         return self.meta_yaml != self.orig.meta_yaml
 

--- a/percy/examples/patch/updater_standalone.py
+++ b/percy/examples/patch/updater_standalone.py
@@ -107,11 +107,9 @@ class Recipe:
         See also `get_raw()` if you want to get the content of the unparsed
         meta.yaml at a specific key.
 
-        Args:
-          path: The "path" to the node. Use numbers for lists ('source/1/url')
+        :param path: The "path" to the node. Use numbers for lists ('source/1/url')
 
-        Returns:
-          a tuple of first_row, first_column, last_row, last_column
+        :returns: A tuple of first_row, first_column, last_row, last_column
         """
         if not path:
             if self.meta_yaml:
@@ -167,12 +165,10 @@ class Recipe:
         I.e., `source/0/url` will always get the first url, whether or
         not the source section is a list.
 
-        Args:
-          path: Path through YAML
-          default: If not KeyError, this value will be returned
-                   if the path does not exist in the recipe
-        Raises:
-          KeyError if no default given and the path does not exist.
+        :param path: Path through YAML
+        :param default: If not KeyError, this value will be returned
+                        if the path does not exist in the recipe
+        :raises: KeyError if no default given and the path does not exist.
         """
         try:
             nodes, keys = self._walk(path)

--- a/percy/examples/patch/updater_standalone.py
+++ b/percy/examples/patch/updater_standalone.py
@@ -1,4 +1,5 @@
-""" Patch a recipe
+"""
+Patch a recipe
 
 """
 
@@ -51,20 +52,27 @@ class Recipe:
         self.load(self.path)
 
     def dump(self):
-        """Dump recipe content"""
+        """
+        Dump recipe content
+        """
         return "\n".join(self.meta_yaml) + "\n"
 
     def save(self):
-        """Save recipe dump to file"""
+        """
+        Save recipe dump to file
+        """
         with open(self.path, "w", encoding="utf-8") as fdes:
             fdes.write(self.dump())
 
     def _set_original(self) -> None:
-        """Store the current state of the recipe as "original" version"""
+        """
+        Store the current state of the recipe as "original" version
+        """
         self.orig = copy.deepcopy(self)
 
     def is_modified(self) -> bool:
-        """Has recipe been modified.
+        """
+        Has recipe been modified.
 
         Returns:
             bool: True if recipe has been modified.
@@ -93,7 +101,8 @@ class Recipe:
         return nodes, keys
 
     def get_raw_range(self, path):
-        """Locate the position of a node in the YAML within the raw text
+        """
+        Locate the position of a node in the YAML within the raw text
 
         See also `get_raw()` if you want to get the content of the unparsed
         meta.yaml at a specific key.
@@ -143,7 +152,8 @@ class Recipe:
         return (start_row, start_col, end_row, end_col)
 
     def get(self, path: str, default: Any = KeyError) -> Any:
-        """Get a value or section from the recipe
+        """
+        Get a value or section from the recipe
 
         >>> recipe.get('requirements/build')
         ['setuptools]

--- a/percy/examples/patch/updater_standalone.py
+++ b/percy/examples/patch/updater_standalone.py
@@ -166,9 +166,8 @@ class Recipe:
         not the source section is a list.
 
         :param path: Path through YAML
-        :param default: If not KeyError, this value will be returned
-                        if the path does not exist in the recipe
-        :raises: KeyError if no default given and the path does not exist.
+        :param default: If not KeyError, this value will be returned if the path does not exist in the recipe
+        :raises KeyError: if no default given and the path does not exist.
         """
         try:
             nodes, keys = self._walk(path)

--- a/percy/examples/preinstall/dry_run.py
+++ b/percy/examples/preinstall/dry_run.py
@@ -13,7 +13,9 @@ def dry_run(
     override_channels=False,
     packages=[],
 ):
-    """Dry-run an environment and return it's json result."""
+    """
+    Dry-run an environment and return it's json result.
+    """
     cmd = f"conda create -n test_env --dry-run --json --solver={solver}"
     for channel in channels:
         cmd += f" -c {channel}"
@@ -40,7 +42,9 @@ def dry_run(
 
 
 def dry_run_assert(subdir, packages):
-    """Dry-run an environment and assert that it succeeds."""
+    """
+    Dry-run an environment and assert that it succeeds.
+    """
     json_result = dry_run(
         subdir=subdir,
         channels=["defaults"],
@@ -59,7 +63,9 @@ def dry_run_assert(subdir, packages):
 
 
 def create_parser() -> argparse.ArgumentParser:
-    """Create command line parser."""
+    """
+    Create command line parser.
+    """
     parser = argparse.ArgumentParser(
         prog="test_env",
         description="Dry-run an environment.",

--- a/percy/examples/py_buildorder/copy_to_www_pkgs_main.py
+++ b/percy/examples/py_buildorder/copy_to_www_pkgs_main.py
@@ -1,4 +1,5 @@
-""" Copy 311 packages to /www/pkgs/main
+"""
+Copy 311 packages to /www/pkgs/main
 """
 
 import argparse
@@ -21,7 +22,9 @@ DEFAULT_PERMISSIONS = 0o664
 
 # A custom formatter for our logging purposes.
 class CustomFormatter(logging.Formatter):
-    """Custom logging format that adds color to different log levels."""
+    """
+    Custom logging format that adds color to different log levels.
+    """
 
     blue = "\033[0;34m"
     yellow = "\x1b[33;20m"

--- a/percy/examples/py_buildorder/find_outdated_with_defaults.py
+++ b/percy/examples/py_buildorder/find_outdated_with_defaults.py
@@ -1,4 +1,5 @@
-"""Script to find local packages at lower version than on defaults.
+"""
+Script to find local packages at lower version than on defaults.
 
 The script considers packages from defaults that depend on python and are
 architecture-specific.
@@ -58,7 +59,9 @@ def depends_on_python(repo_package, python_ref):
 
 
 def _is_newer_than(package, version, build_number):
-    """Returns True when the package is newer than a version and build_number."""
+    """
+    Returns True when the package is newer than a version and build_number.
+    """
     if version > package["vo"]:
         return False
     if version < package["vo"]:

--- a/percy/examples/py_buildorder/gen_python_build_order.py
+++ b/percy/examples/py_buildorder/gen_python_build_order.py
@@ -1,4 +1,5 @@
-""" Generate build scripts to build all packages depending on python.
+"""
+Generate build scripts to build all packages depending on python.
 """
 
 import argparse

--- a/percy/examples/py_buildorder/patch312.py
+++ b/percy/examples/py_buildorder/patch312.py
@@ -72,8 +72,7 @@ class Recipe:
         """
         Has recipe been modified.
 
-        Returns:
-            bool: True if recipe has been modified.
+        :returns: True if recipe has been modified.
         """
         return self.meta_yaml != self.orig.meta_yaml
 

--- a/percy/examples/py_buildorder/patch312.py
+++ b/percy/examples/py_buildorder/patch312.py
@@ -164,9 +164,8 @@ class Recipe:
         not the source section is a list.
 
         :param path: Path through YAML
-        :param default: If not KeyError, this value will be returned
-                        if the path does not exist in the recipe
-        :raises: KeyError if no default given and the path does not exist.
+        :param default: If not KeyError, this value will be returned if the path does not exist in the recipe
+        :raises KeyError: if no default given and the path does not exist.
         """
         try:
             nodes, keys = self._walk(path)

--- a/percy/examples/py_buildorder/patch312.py
+++ b/percy/examples/py_buildorder/patch312.py
@@ -105,11 +105,9 @@ class Recipe:
         See also `get_raw()` if you want to get the content of the unparsed
         meta.yaml at a specific key.
 
-        Args:
-          path: The "path" to the node. Use numbers for lists ('source/1/url')
+        :param path: The "path" to the node. Use numbers for lists ('source/1/url')
 
-        Returns:
-          a tuple of first_row, first_column, last_row, last_column
+        :returns: A tuple of first_row, first_column, last_row, last_column
         """
         if not path:
             if self.meta_yaml:
@@ -165,12 +163,10 @@ class Recipe:
         I.e., `source/0/url` will always get the first url, whether or
         not the source section is a list.
 
-        Args:
-          path: Path through YAML
-          default: If not KeyError, this value will be returned
-                   if the path does not exist in the recipe
-        Raises:
-          KeyError if no default given and the path does not exist.
+        :param path: Path through YAML
+        :param default: If not KeyError, this value will be returned
+                        if the path does not exist in the recipe
+        :raises: KeyError if no default given and the path does not exist.
         """
         try:
             nodes, keys = self._walk(path)

--- a/percy/examples/py_buildorder/patch312.py
+++ b/percy/examples/py_buildorder/patch312.py
@@ -1,4 +1,5 @@
-""" Patch a recipe
+"""
+Patch a recipe
 
 """
 
@@ -49,20 +50,27 @@ class Recipe:
         self.load(self.path)
 
     def dump(self):
-        """Dump recipe content"""
+        """
+        Dump recipe content
+        """
         return "\n".join(self.meta_yaml) + "\n"
 
     def save(self):
-        """Save recipe dump to file"""
+        """
+        Save recipe dump to file
+        """
         with open(self.path, "w", encoding="utf-8") as fdes:
             fdes.write(self.dump())
 
     def _set_original(self) -> None:
-        """Store the current state of the recipe as "original" version"""
+        """
+        Store the current state of the recipe as "original" version
+        """
         self.orig = copy.deepcopy(self)
 
     def is_modified(self) -> bool:
-        """Has recipe been modified.
+        """
+        Has recipe been modified.
 
         Returns:
             bool: True if recipe has been modified.
@@ -91,7 +99,8 @@ class Recipe:
         return nodes, keys
 
     def get_raw_range(self, path):
-        """Locate the position of a node in the YAML within the raw text
+        """
+        Locate the position of a node in the YAML within the raw text
 
         See also `get_raw()` if you want to get the content of the unparsed
         meta.yaml at a specific key.
@@ -141,7 +150,8 @@ class Recipe:
         return (start_row, start_col, end_row, end_col)
 
     def get(self, path: str, default: Any = KeyError) -> Any:
-        """Get a value or section from the recipe
+        """
+        Get a value or section from the recipe
 
         >>> recipe.get('requirements/build')
         ['setuptools]

--- a/percy/examples/py_buildorder/test_install.py
+++ b/percy/examples/py_buildorder/test_install.py
@@ -1,4 +1,5 @@
-"""Test installation of all packages listed in python_full_package_list.yaml
+"""
+Test installation of all packages listed in python_full_package_list.yaml
 
 Usage:
     pytest -n auto \
@@ -21,7 +22,9 @@ def dry_run(
     override_channels=False,
     packages=[],
 ):
-    """Dry-run an environment and return it's json result."""
+    """
+    Dry-run an environment and return it's json result.
+    """
     cmd = f"conda create -n test_env --dry-run --json --solver={solver}"
     for channel in channels:
         cmd += f" -c {channel}"
@@ -50,7 +53,9 @@ def dry_run(
 
 
 def dry_run_assert(solver, packages, channels):
-    """Dry-run an environment and assert that it succeeds."""
+    """
+    Dry-run an environment and assert that it succeeds.
+    """
     json_result = dry_run(
         solver=solver,
         channels=channels,

--- a/percy/parser/_node.py
+++ b/percy/parser/_node.py
@@ -56,8 +56,8 @@ class Node:
     def __eq__(self, other: object) -> bool:
         """
         Determine if two nodes are equal. Useful for `assert` statements in tests.
-        :param other:   Other object to check against
-        :return: True if the two nodes are identical. False otherwise.
+        :param other: Other object to check against
+        :returns: True if the two nodes are identical. False otherwise.
         """
         if not isinstance(other, Node):
             return False
@@ -73,7 +73,7 @@ class Node:
     def __str__(self) -> str:
         """
         Renders the Node as a string. Useful for debugging purposes.
-        :return: The node, as a string
+        :returns: The node, as a string
         """
         value = self.value
         if self.is_comment():
@@ -92,7 +92,7 @@ class Node:
     def short_str(self) -> str:
         """
         Renders the Node as a simple string. Useful for other `__str__()` functions to call.
-        :return: The node, as a simplified string.
+        :returns: The node, as a simplified string.
         """
         if self.is_comment():
             return f"<Comment: {self.comment}>"
@@ -103,21 +103,21 @@ class Node:
     def is_leaf(self) -> bool:
         """
         Indicates if a node is a leaf node
-        :return: True if the node is a leaf. False otherwise.
+        :returns: True if the node is a leaf. False otherwise.
         """
         return not self.children and not self.is_comment()
 
     def is_root(self) -> bool:
         """
         Indicates if a node is a root node
-        :return: True if the node is a root node. False otherwise.
+        :returns: True if the node is a root node. False otherwise.
         """
         return self.value == ROOT_NODE_VALUE
 
     def is_comment(self) -> bool:
         """
         Indicates if a line contains only a comment. When rendered, this will be a comment only-line.
-        :return: True if the node represents only a comment. False otherwise.
+        :returns: True if the node represents only a comment. False otherwise.
         """
         return self.value == Node._sentinel and self.comment and not self.children
 
@@ -133,7 +133,7 @@ class Node:
             - bar
 
         When converted into a Pythonic data structure, the key will point to an `None` value.
-        :return: True if the node represents an empty key. False otherwise.
+        :returns: True if the node represents an empty key. False otherwise.
         """
         return self.key_flag and self.is_leaf()
 
@@ -143,7 +143,7 @@ class Node:
 
         This special case is used in several edge cases. Namely, it allows the rendering algorithm to print such
         key-value pairs on the same line.
-        :return: True if the node represents a single key. False otherwise.
+        :returns: True if the node represents a single key. False otherwise.
         """
         return self.key_flag and len(self.children) == 1 and self.children[0].is_leaf()
 
@@ -151,6 +151,6 @@ class Node:
         """
         Indicates if the node is a list member that contains other collection types. In other words, this node has no
         value itself BUT it contains children that do.
-        :return: True if the noe represents an element that is a collection. False otherwise.
+        :returns: True if the noe represents an element that is a collection. False otherwise.
         """
         return self.value == Node._sentinel and self.list_member_flag and len(self.children)

--- a/percy/parser/_selector_info.py
+++ b/percy/parser/_selector_info.py
@@ -22,7 +22,7 @@ class SelectorInfo(NamedTuple):
     def __str__(self) -> str:
         """
         Generates the string form of a `SelectorInfo` object. Useful for debugging.
-        :return: String representation of a `SelectorInfo` instance
+        :returns: String representation of a `SelectorInfo` instance
         """
         path_str = stack_path_to_str(self.path.copy())
         return f"{self.node.short_str()} -> {path_str}"

--- a/percy/parser/_traverse.py
+++ b/percy/parser/_traverse.py
@@ -22,9 +22,9 @@ def remap_child_indices_virt_to_phys(children: list[Node]) -> list[int]:
     rely on our implementation details and should be able to access a member of a list as expected. In other words,
     users will not consider comments in a list as indexable list members.
 
-    :param children:    Child node list to process.
-    :return: A list of indices. Indexing this list with the "virtual" (user-provided) index will return the "physical"
-             list position.
+    :param children: Child node list to process.
+    :returns: A list of indices. Indexing this list with the "virtual" (user-provided) index will return the "physical"
+        list position.
     """
     mapping: list[int] = []
     cntr = 0
@@ -42,9 +42,9 @@ def remap_child_indices_phys_to_virt(children: list[Node]) -> list[int]:
     """
     Produces the "inverted" table created by `remap_child_indices_virt_to_phys()`.
     See `remap_child_indices_virt_to_phys()` for more details.
-    :param children:    Child node list to process.
-    :return: A list of indices. Indexing this list with the "physical" (class-provided) index will return the "virtual"
-             list position.
+    :param children: Child node list to process.
+    :returns: A list of indices. Indexing this list with the "physical" (class-provided) index will return the "virtual"
+        list position.
     """
     mapping: list[int] = remap_child_indices_virt_to_phys(children)
     new_mapping: list[int] = [0] * len(children)
@@ -56,9 +56,9 @@ def remap_child_indices_phys_to_virt(children: list[Node]) -> list[int]:
 def _traverse_recurse(node: Node, path: StrStack) -> Optional[Node]:
     """
     Recursive helper function for traversing a tree.
-    :param node:    Current node on the tree.
-    :param path:    Path, as a stack, that describes a location in the tree.
-    :return: `Node` object if a node is found in the parse tree at that path. Otherwise returns `None`.
+    :param node: Current node on the tree.
+    :param path: Path, as a stack, that describes a location in the tree.
+    :returns: `Node` object if a node is found in the parse tree at that path. Otherwise returns `None`.
     """
     if len(path) == 0:
         return node
@@ -97,9 +97,9 @@ def traverse(node: Optional[Node], path: StrStack) -> Optional[Node]:
     Given a path in the recipe tree, traverse the tree and return the node at that path.
 
     If no Node is found at that path, return `None`.
-    :param node:    Starting node of the tree/branch to traverse.
-    :param path:    Path, as a stack, that describes a location in the tree.
-    :return: `Node` object if a node is found in the parse tree at that path. Otherwise returns `None`.
+    :param node: Starting node of the tree/branch to traverse.
+    :param path: Path, as a stack, that describes a location in the tree.
+    :returns: `Node` object if a node is found in the parse tree at that path. Otherwise returns `None`.
     """
     # Bootstrap recursive edge cases
     if node is None:
@@ -118,12 +118,12 @@ def traverse(node: Optional[Node], path: StrStack) -> Optional[Node]:
 def traverse_with_index(root: Node, path: StrStack) -> tuple[Optional[Node], int]:
     """
     Given a path, return the node of interest OR the parent node with indexing information, if the node is in a list.
-    :param root:    Starting node of the tree/branch to traverse.
-    :param path:    Path, as a stack, that describes a location in the tree.
-    :return: A tuple containing two items:
-                - `Node` object if a node is found in the parse tree at that path. Otherwise returns `None`. If the
-                    path terminates in an index, the parent is returned with the index location.
-                - If the node is a member of a list, the index returned will be >= 0.
+    :param root: Starting node of the tree/branch to traverse.
+    :param path: Path, as a stack, that describes a location in the tree.
+    :returns: A tuple containing two items: - `Node` object if a node is found in the parse tree at that path. Otherwise
+        returns `None`. If the
+            path terminates in an index, the parent is returned with the index location.
+        - If the node is a member of a list, the index returned will be >= 0.
     """
     if len(path) == 0:
         return None
@@ -153,11 +153,11 @@ def traverse_all(
     NOTE: The paths provided will return virtual indices, not physical indices. In other words, comments in a list do
           not count towards the index position of a list member.
 
-    :param node:    Node to start with
-    :param func:    Function to apply against all traversed nodes.
-    :param path:    CALLERS: DO NOT SET. This value tracks the current path of a node. This should only be specified in
-                    recursive calls to this function. Tuples are used for their immutability, so paths change based on
-                    the current stack frame.
+    :param node: Node to start with
+    :param func: Function to apply against all traversed nodes.
+    :param path: CALLERS: DO NOT SET. This value tracks the current path of a node. This should only be specified in
+        recursive calls to this function. Tuples are used for their immutability, so paths change based on the current
+        stack frame.
     :param idx_num: CALLERS: DO NOT SET. Used in recursive calls to track the index position of a list-member node.
     """
     if node is None:

--- a/percy/parser/_utils.py
+++ b/percy/parser/_utils.py
@@ -18,7 +18,7 @@ def str_to_stack_path(path: str) -> StrStack:
     For example:
         "/foo/bar/baz" -> ["baz", "bar", "foo", "/"]
     :param path: Path to deconstruct into a stack
-    :return: Path, described as a stack of strings.
+    :returns: Path, described as a stack of strings.
     """
     # TODO: validate the path starts with `/` (root)
 
@@ -41,8 +41,8 @@ def stack_path_to_str(path_stack: StrStack | StrStackImmutable) -> str:
     Takes a stack that represents a path and converts it into a string. String paths are used by callers, stacks are
     used internally.
 
-    :param path_stack:  Stack to construct back into a string.
-    :return: Path, described as a string.
+    :param path_stack: Stack to construct back into a string.
+    :returns: Path, described as a string.
     """
     # Normalize type if a tuple is given.
     if isinstance(path_stack, tuple):
@@ -61,8 +61,8 @@ def num_tab_spaces(s: str) -> int:
     """
     Counts the number of spaces at the start of the string. Used to indicate depth of a field in a YAML file (the YAML
     specification dictates only spaces can be used for indenting).
-    :param s:   Target string
-    :return: Number of preceding spaces in a string
+    :param s: Target string
+    :returns: Number of preceding spaces in a string
     """
     cntr: int = 0
     for c in s:
@@ -76,9 +76,9 @@ def num_tab_spaces(s: str) -> int:
 def substitute_markers(s: str, subs: list[str]) -> str:
     """
     Given a string, replace substitution markers with the original Jinja template from a list of options.
-    :param s:       String to replace substitution markers with
-    :param subs:    List of substitutions to make, in order of appearance
-    :return: New string, with substitutions removed
+    :param s: String to replace substitution markers with
+    :param subs: List of substitutions to make, in order of appearance
+    :returns: New string, with substitutions removed
     """
     while s.find(PERCY_SUB_MARKER) >= 0 and len(subs):
         s = s.replace(PERCY_SUB_MARKER, subs[0], 1)
@@ -90,9 +90,9 @@ def stringify_yaml(val: Primitives, multiline_flag: bool = False) -> Primitives:
     """
     Special function for handling edge cases when converting values back to YAML.
     :param val: Value to check
-    :param multiline_flag:  (Optional) If the value being processed is a multiline string, set this flag to True to
-                            prevent unintended quote-escaping.
-    :return: YAML version of a value, as a string.
+    :param multiline_flag: (Optional) If the value being processed is a multiline string, set this flag to True to
+        prevent unintended quote-escaping.
+    :returns: YAML version of a value, as a string.
     """
     # None -> null
     if val is None:

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -76,12 +76,11 @@ class RecipeParser:
     def _parse_yaml(s: str, parser: Optional[RecipeParser] = None) -> JsonType:
         """
         Parse a line (or multiple) of YAML into a Pythonic data structure
-        :param s:       String to parse
-        :param parser:  (Optional) If provided, this will substitute Jinja variables with values specified in in the
-                        recipe file. Since `_parse_yaml()` is critical to constructing recipe files, this function must
-                        remain static. Also, during construction, we shouldn't be using a variables until the entire
-                        recipe is read/parsed.
-        :return: Pythonic data corresponding to the line of YAML
+        :param s: String to parse
+        :param parser: (Optional) If provided, this will substitute Jinja variables with values specified in in the
+            recipe file. Since `_parse_yaml()` is critical to constructing recipe files, this function must remain
+            static. Also, during construction, we shouldn't be using a variables until the entire recipe is read/parsed.
+        :returns: Pythonic data corresponding to the line of YAML
         """
 
         # Recursive helper function used when we need to perform variable substitutions
@@ -124,8 +123,8 @@ class RecipeParser:
 
         Latest YAML spec can be found here: https://yaml.org/spec/1.2.2/
 
-        :param s:   Pre-stripped (no leading/trailing spaces), non-Jinja line of a recipe file
-        :return: A Node representing a line of the conda-formatted YAML.
+        :param s: Pre-stripped (no leading/trailing spaces), non-Jinja line of a recipe file
+        :returns: A Node representing a line of the conda-formatted YAML.
         """
         # Use PyYaml to safely/easily/correctly parse single lines of YAML.
         output = RecipeParser._parse_yaml(s)
@@ -214,9 +213,9 @@ class RecipeParser:
     def _render_jinja_vars(self, s: str) -> JsonType:
         """
         Helper function that replaces Jinja substitutions with their actual set values.
-        :param s:    String to be re-rendered
-        :return: The original value, augmented with Jinja substitutions. If substitutions have taken place, the type is
-                 re-evaluated.
+        :param s: String to be re-rendered
+        :returns: The original value, augmented with Jinja substitutions. If substitutions have taken place, the type is
+            re-evaluated.
         """
         replacement = False
         # Search the string, replacing all substitutions we can recognize
@@ -267,8 +266,7 @@ class RecipeParser:
     def __init__(self, content: str):
         """
         Constructs a RecipeParser instance.
-        :param content: conda-build formatted recipe file, as a single text
-                        string.
+        :param content: conda-build formatted recipe file, as a single text string.
         """
         # The initial, raw, text is preserved for diffing and debugging purposes
         self._init_content: Final[str] = content
@@ -360,9 +358,9 @@ class RecipeParser:
     def _str_tree_recurse(node: Node, depth: int, lines: list[str]) -> str:
         """
         Helper function that renders a parse tree as a text-based dependency tree. Useful for debugging.
-        :param node:    Node of interest
-        :param depth:   Current depth of the node
-        :param lines:   Accumulated list of lines to text to render
+        :param node: Node of interest
+        :param depth: Current depth of the node
+        :param lines: Accumulated list of lines to text to render
         """
         spaces = TAB_AS_SPACES * depth
         branch = "" if depth == 0 else "|- "
@@ -373,7 +371,7 @@ class RecipeParser:
     def __str__(self) -> str:
         """
         Casts the parser into a string. Useful for debugging.
-        :return: String representation of the recipe file
+        :returns: String representation of the recipe file
         """
         s = "--------------------\n"
         tree_lines: list[str] = []
@@ -395,8 +393,8 @@ class RecipeParser:
     def __eq__(self, other: object) -> bool:
         """
         Checks if two recipe representations match entirely
-        :param other:   Other recipe parser instance to check against.
-        :return: True if both recipes contain the same current state. False otherwise.
+        :param other: Other recipe parser instance to check against.
+        :returns: True if both recipes contain the same current state. False otherwise.
         """
         if not isinstance(other, RecipeParser):
             raise TypeError
@@ -405,14 +403,14 @@ class RecipeParser:
     def is_modified(self) -> bool:
         """
         Indicates if the recipe has been changed since construction.
-        :return: True if the recipe has changed. False otherwise.
+        :returns: True if the recipe has changed. False otherwise.
         """
         return self._is_modified
 
     def has_unsupported_statements(self) -> bool:
         """
         Runs a series of checks against the original recipe file.
-        :return: True if the recipe has statements we do not currently support. False otherwise.
+        :returns: True if the recipe has statements we do not currently support. False otherwise.
         """
         # TODO complete
         raise NotImplementedError
@@ -421,10 +419,10 @@ class RecipeParser:
     def _render_tree(node: Node, depth: int, lines: list[str], parent: Optional[Node] = None) -> None:
         """
         Recursive helper function that traverses the parse tree to generate a file.
-        :param node:    Current node in the tree
-        :param depth:   Current depth of the recursion
-        :param lines:   Accumulated list of lines in the recipe file
-        :param parent:  (Optional) Parent node to the current node. Set by recursive calls only.
+        :param node: Current node in the tree
+        :param depth: Current depth of the recursion
+        :param lines: Accumulated list of lines in the recipe file
+        :param parent: (Optional) Parent node to the current node. Set by recursive calls only.
         """
         spaces = TAB_AS_SPACES * depth
 
@@ -502,7 +500,7 @@ class RecipeParser:
     def render(self) -> str:
         """
         Takes the current state of the parse tree and returns the recipe file as a string.
-        :return: String representation of the recipe file
+        :returns: String representation of the recipe file
         """
         lines = []
 
@@ -525,9 +523,9 @@ class RecipeParser:
     def _render_object_tree(self, node: Node, replace_variables: bool, data: JsonType) -> None:
         """
         Recursive helper function that traverses the parse tree to generate a Pythonic data object.
-        :param node:                Current node in the tree
-        :param replace_variables:   If set to True, this replaces all variable substitutions with their set values.
-        :param data:                Accumulated data structure
+        :param node: Current node in the tree
+        :param replace_variables: If set to True, this replaces all variable substitutions with their set values.
+        :param data: Accumulated data structure
         """
         # Ignore comment-only lines
         if node.is_comment():
@@ -580,9 +578,9 @@ class RecipeParser:
         """
         Takes the underlying state of the parse tree and produces a Pythonic object/dictionary representation. Analogous
         to `json.load()`.
-        :param replace_variables:   (Optional) If set to True, this replaces all variable substitutions with their set
-                                    values.
-        :return: Pythonic data object representation of the recipe.
+        :param replace_variables: (Optional) If set to True, this replaces all variable substitutions with their set
+            values.
+        :returns: Pythonic data object representation of the recipe.
         """
         data: JsonType = {}
 
@@ -600,7 +598,7 @@ class RecipeParser:
     def list_value_paths(self) -> list[str]:
         """
         Provides a list of all known terminal paths. This can be used by the caller to perform search operations.
-        :return: List of all terminal paths in the parse tree.
+        :returns: List of all terminal paths in the parse tree.
         """
         lst: list[str] = []
 
@@ -615,8 +613,8 @@ class RecipeParser:
         """
         Determines if a value (via a path) is contained in this recipe. This also allows the caller to determine if a
         path exists.
-        :param path:    JSON patch (RFC 6902)-style path to a value.
-        :return: True if the path exists. False otherwise.
+        :param path: JSON patch (RFC 6902)-style path to a value.
+        :returns: True if the path exists. False otherwise.
         """
         path_stack = str_to_stack_path(path)
         return traverse(self._root, path_stack) is not None
@@ -624,12 +622,12 @@ class RecipeParser:
     def get_value(self, path: str, default: JsonType = _sentinel, sub_vars: bool = False) -> JsonType:
         """
         Retrieves a value at a given path. If the value is not found, return a specified default value or throw.
-        :param path:        JSON patch (RFC 6902)-style path to a value.
-        :param default:     (Optional) If the value is not found, return this value instead.
-        :param sub_vars:    (Optional) If set to True and the value contains a Jinja template variable, the Jinja value
-                            will be "rendered".
+        :param path: JSON patch (RFC 6902)-style path to a value.
+        :param default: (Optional) If the value is not found, return this value instead.
+        :param sub_vars: (Optional) If set to True and the value contains a Jinja template variable, the Jinja value
+            will be "rendered".
         :raises KeyError: If the value is not found AND no default is specified
-        :return: If found, the value in the recipe at that path. Otherwise, the caller-specified default value.
+        :returns: If found, the value in the recipe at that path. Otherwise, the caller-specified default value.
         """
         path_stack = str_to_stack_path(path)
         node = traverse(self._root, path_stack)
@@ -674,9 +672,9 @@ class RecipeParser:
 
         NOTE: This only supports searching for "primitive" values, i.e. you cannot search for collections.
 
-        :param value:   Value to find in the recipe.
+        :param value: Value to find in the recipe.
         :raises ValueError: If the value provided is not a primitive type.
-        :return: List of paths where the value can be found.
+        :returns: List of paths where the value can be found.
         """
         if not isinstance(value, PRIMITIVES_TUPLE):
             raise ValueError(f"A non-primitive value was provided: {value}")
@@ -697,7 +695,7 @@ class RecipeParser:
     def list_variables(self) -> list[str]:
         """
         Returns variables found in the recipe, sorted by first appearance.
-        :return: List of variables found in the recipe.
+        :returns: List of variables found in the recipe.
         """
         return list(self._vars_tbl.keys())
 
@@ -705,7 +703,7 @@ class RecipeParser:
         """
         Determines if a variable is set in this recipe.
         :param var: Variable to check for.
-        :return: True if a variable name is found in this recipe. False otherwise.
+        :returns: True if a variable name is found in this recipe. False otherwise.
         """
         return var in self._vars_tbl
 
@@ -713,10 +711,10 @@ class RecipeParser:
         """
         Returns the value of a variable set in the recipe. If specified, a default value will be returned if the
         variable name is not found.
-        :param var:     Variable of interest check for.
+        :param var: Variable of interest check for.
         :param default: (Optional) If the value is not found, return this value instead.
-        :raises KeyError:   If the value is not found AND no default is specified
-        :return: The value (or specified default value if not found) of the variable name provided.
+        :raises KeyError: If the value is not found AND no default is specified
+        :returns: The value (or specified default value if not found) of the variable name provided.
         """
         if var not in self._vars_tbl:
             if default == RecipeParser._sentinel:
@@ -727,8 +725,8 @@ class RecipeParser:
     def set_variable(self, var: str, value: Primitives) -> None:
         """
         Adds or changes an existing Jinja variable.
-        :param var:     Variable to modify
-        :param value:   Value to set
+        :param var: Variable to modify
+        :param value: Value to set
         """
         self._vars_tbl[var] = value
         self._is_modified = True
@@ -747,7 +745,7 @@ class RecipeParser:
         """
         Returns a list of paths that use particular variables.
         :param var: Variable of interest
-        :return: List of paths that use a variable, sorted by first appearance.
+        :returns: List of paths that use a variable, sorted by first appearance.
         """
         if var not in self._vars_tbl:
             return []
@@ -771,15 +769,15 @@ class RecipeParser:
     def list_selectors(self) -> list[str]:
         """
         Returns selectors found in the recipe, sorted by first appearance.
-        :return: List of selectors found in the recipe.
+        :returns: List of selectors found in the recipe.
         """
         return list(self._selector_tbl.keys())
 
     def contains_selector(self, selector: str) -> bool:
         """
         Determines if a selector expression is present in this recipe.
-        :param selector:    Selector to check for.
-        :return: True if a selector is found in this recipe. False otherwise.
+        :param selector: Selector to check for.
+        :returns: True if a selector is found in this recipe. False otherwise.
         """
         return selector in self._selector_tbl
 
@@ -790,8 +788,8 @@ class RecipeParser:
 
         Selector paths will be ordered by the line they appear on in the file.
 
-        :param selector:    Selector of interest.
-        :return: A list of all known paths that use a particular selector
+        :param selector: Selector of interest.
+        :returns: A list of all known paths that use a particular selector
         """
         # We return a tuple so that caller doesn't accidentally modify a private member variable.
         if not self.contains_selector(selector):
@@ -810,10 +808,10 @@ class RecipeParser:
     def add_selector(self, path: str, selector: str, mode: SelectorConflictMode = SelectorConflictMode.REPLACE) -> None:
         """
         Given a path, add a selector (include the surrounding brackets) to the line denoted by path.
-        :param path:        Path to add a selector to
-        :param selector:    Selector statement to add
-        :param mode:        (Optional) Indicates how to handle a conflict if a selector already exists at this path.
-        :raises KeyError:   If the path provided is not found
+        :param path: Path to add a selector to
+        :param selector: Selector statement to add
+        :param mode: (Optional) Indicates how to handle a conflict if a selector already exists at this path.
+        :raises KeyError: If the path provided is not found
         :raises ValueError: If the selector provided is malformed
         """
         path_stack = str_to_stack_path(path)
@@ -857,9 +855,9 @@ class RecipeParser:
         Given a path, remove a selector to the line denoted by path.
         - If a selector does not exist, nothing happens.
         - If a comment exists after the selector, keep it, discard the selector.
-        :param path:        Path to add a selector to
-        :raises KeyError:   If the path provided is not found
-        :return: If found, the selector removed (includes surrounding brackets). Otherwise, returns None
+        :param path: Path to add a selector to
+        :raises KeyError: If the path provided is not found
+        :returns: If found, the selector removed (includes surrounding brackets). Otherwise, returns None
         """
         path_stack = str_to_stack_path(path)
         node = traverse(self._root, path_stack)
@@ -896,10 +894,10 @@ class RecipeParser:
         """
         Indicates if the target node to perform a patch operation against is a valid node. This is based on the RFC spec
         for JSON patching paths.
-        :param node:        Target node to validate
-        :param node_idx:    If the caller is evaluating that a list member, exists, this is the index into that list.
-                            Otherwise this value should be less than 0.
-        :return: True if the node can be patched. False otherwise.
+        :param node: Target node to validate
+        :param node_idx: If the caller is evaluating that a list member, exists, this is the index into that list.
+            Otherwise this value should be less than 0.
+        :returns: True if the node can be patched. False otherwise.
         """
         # Path not found
         if node is None:
@@ -926,12 +924,10 @@ class RecipeParser:
         Finds the target node of an `add()` operation, along with some supporting information.
 
         This function does not modify the parse tree.
-        :param path_stack:  Path that describes a location in the tree, as a list, treated like a stack.
-        :return: A tuple containing:
-                   - The target node, if found (or the parent node if the target is a list member)
-                   - The index of a node if the target is a list member
-                   - An additional path that needs to be created, if applicable
-                   - A flag indicating if the new data will be appended to a list
+        :param path_stack: Path that describes a location in the tree, as a list, treated like a stack.
+        :returns: A tuple containing: - The target node, if found (or the parent node if the target is a list member) -
+            The index of a node if the target is a list member - An additional path that needs to be created, if
+            applicable - A flag indicating if the new data will be appended to a list
         """
         if len(path_stack) == 0:
             return None, -1, "", False
@@ -957,8 +953,8 @@ class RecipeParser:
     def _patch_add(self, _: str, path_stack: StrStack, value: JsonType) -> bool:
         """
         Performs a JSON patch `add` operation.
-        :param path_stack:  Path that describes a location in the tree, as a list, treated like a stack.
-        :param value:       Value to add.
+        :param path_stack: Path that describes a location in the tree, as a list, treated like a stack.
+        :param value: Value to add.
         """
         # NOTE from the RFC:
         #   Because this operation is designed to add to existing objects and arrays, its target location will often
@@ -998,7 +994,7 @@ class RecipeParser:
     ) -> bool:
         """
         Performs a JSON patch `remove` operation.
-        :param path_stack:  Path that describes a location in the tree, as a list, treated like a stack.
+        :param path_stack: Path that describes a location in the tree, as a list, treated like a stack.
         """
         if len(path_stack) == 0:
             return False
@@ -1031,8 +1027,8 @@ class RecipeParser:
     def _patch_replace(self, _: str, path_stack: StrStack, value: JsonType) -> bool:
         """
         Performs a JSON patch `replace` operation.
-        :param path_stack:  Path that describes a location in the tree, as a list, treated like a stack.
-        :param value:       Value to update with.
+        :param path_stack: Path that describes a location in the tree, as a list, treated like a stack.
+        :param value: Value to update with.
         """
         node, node_idx = traverse_with_index(self._root, path_stack)
         if not RecipeParser._is_valid_patch_node(node, node_idx):
@@ -1057,9 +1053,9 @@ class RecipeParser:
     def _patch_move(self, path: str, path_stack: StrStack, value_from: JsonType) -> bool:
         """
         Performs a JSON patch `add` operation.
-        :param path:        Path as a string.
-        :param path_stack:  Path that describes a location in the tree, as a list, treated like a stack.
-        :param value_from:  The "from" value in the JSON payload, i.e. the path the value originates from.
+        :param path: Path as a string.
+        :param path_stack: Path that describes a location in the tree, as a list, treated like a stack.
+        :param value_from: The "from" value in the JSON payload, i.e. the path the value originates from.
         """
         # NOTE from the RFC:
         #   This operation is functionally identical to a "remove" operation on the "from" location, followed
@@ -1083,11 +1079,9 @@ class RecipeParser:
     def _patch_copy(self, path: str, path_stack: StrStack, value_from: JsonType) -> bool:
         """
         Performs a JSON patch `add` operation.
-        :param path:        Path as a string.
-        :param path_stack:  Path that describes a location in the tree, as a
-                            list, treated like a stack.
-        :param value_from:  The "from" value in the JSON payload, i.e. the
-                            path the value originates from.
+        :param path: Path as a string.
+        :param path_stack: Path that describes a location in the tree, as a list, treated like a stack.
+        :param value_from: The "from" value in the JSON payload, i.e. the path the value originates from.
         """
         # NOTE from the RFC:
         #   This operation is functionally identical to an "add" operation at the target location using the value
@@ -1104,8 +1098,8 @@ class RecipeParser:
     def _patch_test(self, path: str, _: StrStack, value: JsonType) -> bool:
         """
         Performs a JSON patch `test` operation.
-        :param path:    Path as a string. Useful for invoking public class members.
-        :param value:   Value to evaluate against.
+        :param path: Path as a string. Useful for invoking public class members.
+        :param value: Value to evaluate against.
         """
         try:
             return self.get_value(path) == value
@@ -1144,10 +1138,10 @@ class RecipeParser:
           - copy
           - test
 
-        :param patch:                           JSON-patch payload to operate with.
-        :raises JsonPatchValidationException:   If the JSON-patch payload does not conform to our schema/spec.
-        :return: If the calling code attempts to perform the `test` operation, this indicates the return value of the
-                 `test` request. In other words, if `value` matches the target variable, return True. False otherwise.
+        :param patch: JSON-patch payload to operate with.
+        :raises JsonPatchValidationException: If the JSON-patch payload does not conform to our schema/spec.
+        :returns: If the calling code attempts to perform the `test` operation, this indicates the return value of the
+            `test` request. In other words, if `value` matches the target variable, return True. False otherwise.
         """
         # Validate the patch schema
         try:
@@ -1191,10 +1185,10 @@ class RecipeParser:
         NOTE: This function only searches against primitive values. All variables and selectors can be fully provided by
               using their respective `list_*()` functions.
 
-        :param regex:           Regular expression to match with
+        :param regex: Regular expression to match with
         :param include_comment: (Optional) If set to `True`, this function will execute the regular expression on values
-                                WITH their comments provided. For example: `42  # This is a comment`
-        :return: Returns a list of paths where the matched value was found.
+            WITH their comments provided. For example: `42  # This is a comment`
+        :returns: Returns a list of paths where the matched value was found.
         """
         re_obj = re.compile(regex)
         paths: list[str] = []
@@ -1213,12 +1207,12 @@ class RecipeParser:
     def search_and_patch(self, regex: str, patch: JsonPatchType, include_comment: bool = False) -> bool:
         """
         Given a regex string and a JSON patch, apply the patch to any values that match the search expression.
-        :param regex:           Regular expression to match with
-        :param patch:           JSON patch to perform. NOTE: The `path` field will be replaced with the path(s) found,
-                                so it does not need to be provided.
+        :param regex: Regular expression to match with
+        :param patch: JSON patch to perform. NOTE: The `path` field will be replaced with the path(s) found, so it does
+            not need to be provided.
         :param include_comment: (Optional) If set to `True`, this function will execute the regular expression on values
-                                WITH their comments provided. For example: `42  # This is a comment`
-        :return: Returns a list of paths where the matched value was found.
+            WITH their comments provided. For example: `42  # This is a comment`
+        :returns: Returns a list of paths where the matched value was found.
         """
         paths = self.search(regex, include_comment)
         summation: bool = True
@@ -1231,7 +1225,7 @@ class RecipeParser:
         """
         Returns a git-like-styled diff of the current recipe state with original state of the recipe. Useful for
         debugging and providing users with some feedback.
-        :return: User-friendly displayable string that represents notifications made to the recipe.
+        :returns: User-friendly displayable string that represents notifications made to the recipe.
         """
         if not self.is_modified():
             return ""

--- a/percy/render/_dumper.py
+++ b/percy/render/_dumper.py
@@ -41,9 +41,8 @@ def _dump_render_results_ruamel(render_results: list, out: TextIO = sys.stdout) 
     """
     Dumps a list of rendered variants of a recipe.
 
-    Args:
-        render_results: List of rendered variants.
-        out: Output stream. Defaults to sys.stdout.
+    :param render_results: List of rendered variants.
+    :param out: Output stream. Defaults to sys.stdout.
 
     """
     data_to_dump = []
@@ -62,9 +61,8 @@ def _dump_render_results_yaml(render_results: list, out: TextIO = sys.stdout) ->
     """
     Dumps a list of rendered variants of a recipe.
 
-    Args:
-        render_results: List of rendered variants.
-        out: Output stream. Defaults to sys.stdout.
+    :param render_results: List of rendered variants.
+    :param out: Output stream. Defaults to sys.stdout.
 
     """
 

--- a/percy/render/_dumper.py
+++ b/percy/render/_dumper.py
@@ -43,7 +43,6 @@ def _dump_render_results_ruamel(render_results: list, out: TextIO = sys.stdout) 
 
     :param render_results: List of rendered variants.
     :param out: Output stream. Defaults to sys.stdout.
-
     """
     data_to_dump = []
     for render_result in render_results:
@@ -63,7 +62,6 @@ def _dump_render_results_yaml(render_results: list, out: TextIO = sys.stdout) ->
 
     :param render_results: List of rendered variants.
     :param out: Output stream. Defaults to sys.stdout.
-
     """
 
     class _MetaYaml(dict):

--- a/percy/render/_dumper.py
+++ b/percy/render/_dumper.py
@@ -38,7 +38,8 @@ FIELDS: Final[list[str]] = [
 
 # TODO Fix: `list` type is unspecified to prevent circular dependency. Should be `list[Recipe]`.
 def _dump_render_results_ruamel(render_results: list, out: TextIO = sys.stdout) -> None:
-    """Dumps a list of rendered variants of a recipe.
+    """
+    Dumps a list of rendered variants of a recipe.
 
     Args:
         render_results: List of rendered variants.
@@ -58,7 +59,8 @@ def _dump_render_results_ruamel(render_results: list, out: TextIO = sys.stdout) 
 
 # TODO Fix: `list` type is unspecified to prevent circular dependency. Should be `list[Recipe]`.
 def _dump_render_results_yaml(render_results: list, out: TextIO = sys.stdout) -> None:
-    """Dumps a list of rendered variants of a recipe.
+    """
+    Dumps a list of rendered variants of a recipe.
 
     Args:
         render_results: List of rendered variants.

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -152,7 +152,9 @@ def apply_selector(data: str, selector_dict: dict[str, Any]) -> list[str]:
 
 
 def _get_template(meta_yaml, selector_dict):
-    """Create a Jinja2 template from the current raw recipe"""
+    """
+    Create a Jinja2 template from the current raw recipe
+    """
     # This function exists because the template cannot be pickled.
     # Storing it means the recipe cannot be pickled, which in turn
     # means we cannot pass it to ProcessExecutors.
@@ -173,11 +175,11 @@ def render(
     - render template
     - parse yaml
     - normalize
-    :param recipe_dir:      Directory that contains the target `meta.yaml` file.
-    :param meta_yaml:       Raw YAML text string from the file.
-    :param selector_dict:   Dictionary of selector statements
-    :param renderer_type:   Rendering engine to target
-    :return: Parsed YAML, as a dictionary of keys and values.
+    :param recipe_dir: Directory that contains the target `meta.yaml` file.
+    :param meta_yaml: Raw YAML text string from the file.
+    :param selector_dict: Dictionary of selector statements
+    :param renderer_type: Rendering engine to target
+    :returns: Parsed YAML, as a dictionary of keys and values.
     """
 
     if not renderer_type:

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -128,12 +128,10 @@ _jinja_silent_undef = jinja2.Environment(undefined=_JinjaSilentUndefined)
 def apply_selector(data: str, selector_dict: dict[str, Any]) -> list[str]:
     """Apply selectors # [...]
 
-    Args:
-        data: Raw meta yaml string
-        selector_dict: Selector configuration.
+    :param data: Raw meta yaml string
+    :param selector_dict: Selector configuration.
 
-    Returns:
-        meta yaml filtered based on selectors, as a list of string.
+    :returns:    Meta yaml filtered based on selectors, as a list of string.
     """
     updated_data = []
     for line in data.splitlines():

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -20,7 +20,9 @@ from percy.render.recipe import Package, RendererType, render
 
 
 class PackageNode:
-    """A node representing a package"""
+    """
+    A node representing a package
+    """
 
     aggregate = None
     nodes = {}
@@ -57,7 +59,8 @@ class PackageNode:
 
     @classmethod
     def init(cls, aggregate: "Aggregate"):
-        """Initialize a dependency tree.
+        """
+        Initialize a dependency tree.
 
         Args:
             aggregate (Aggregate): The aggregate object.
@@ -74,7 +77,8 @@ class PackageNode:
         origin_section: str = "run",
         parent: "PackageNode" = None,
     ) -> "PackageNode":
-        """Make a node representing a package.
+        """
+        Make a node representing a package.
 
         Args:
             package_name (str): The name of the package.

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -16,7 +16,8 @@ from typing import Any, Optional
 
 import yaml
 
-from percy.render.recipe import Package, RendererType, render
+from percy.render._renderer import RendererType
+from percy.render.recipe import Package, render
 
 
 class PackageNode:
@@ -37,11 +38,10 @@ class PackageNode:
     ):
         """PackageNode constructor
 
-        Args:
-            parent (PackageNode): The parent node.
-            package_name (str): The package name.
-            package (Package): The corresponding rendered package.
-            is_run (bool): If this is coming from a run dependency.
+        :param parent: The parent node.
+        :param package_name: The package name.
+        :param package: The corresponding rendered package.
+        :param is_run: If this is coming from a run dependency.
         """
         self.parents = set([parent])
         self.package_name = package_name
@@ -62,8 +62,7 @@ class PackageNode:
         """
         Initialize a dependency tree.
 
-        Args:
-            aggregate (Aggregate): The aggregate object.
+        :param aggregate: The aggregate object.
         """
         PackageNode.aggregate = aggregate
         PackageNode.nodes = {}
@@ -80,14 +79,12 @@ class PackageNode:
         """
         Make a node representing a package.
 
-        Args:
-            package_name (str): The name of the package.
-            walk_up_sections (tuple): Call make_node on dependencies from these sections.
-            origin_section (str, optional): If the package was used in a run section or other. Defaults to "run".
-            parent (PackageNode, optional): Parent node. Defaults to None.
+        :param package_name: The name of the package.
+        :param walk_up_sections: Call make_node on dependencies from these sections.
+        :param origin_section: If the package was used in a run section or other. Defaults to "run".
+        :param parent: Parent node. Defaults to None.
 
-        Returns:
-            PackageNode: The package node.
+        :returns: PackageNode: The package node.
         """
 
         node = None
@@ -203,9 +200,8 @@ class Aggregate:
     def __init__(self, aggregate_path: str, manifest_path: Optional[str] = None):
         """Constructor
 
-        Args:
-            aggregate_path: Aggregate local path.
-            manifest_path:  (Optional) Path to the manifest file
+        :param aggregate_path: Aggregate local path.
+        :param manifest_path:  (Optional) Path to the manifest file
         """
 
         # get local aggregate info
@@ -261,11 +257,9 @@ class Aggregate:
     def _get_feedstock_git_repo(self, feedstock_path_rel: Path) -> Feedstock:
         """Get Feedsotck object from feedstock local path.
 
-        Args:
-            feedstock_path_rel (Path): Feedsotck local path.
+        :param feedstock_path_rel: Feedsotck local path.
 
-        Returns:
-            Feedstock: Feedstock representation.
+        :returns Feedstock: Feedstock representation.
         """
         feedstock = self.submodules.get(feedstock_path_rel.name, None)
         if feedstock:
@@ -292,14 +286,12 @@ class Aggregate:
 
             This populates attributes packages and feedstocks.
 
-        Args:
-            subdir:     The subdir for which to load the feedstocks. Defaults to "linux-64".
-            python:     The python version for which to load the feedstocks. Defaults to "3.10".
-            others:     A variant dictionary. E.g. {"blas_impl" : "openblas"} Defaults to None.
-            renderer:   Rendering engine to use to interpret YAML
+        :param subdir:     The subdir for which to load the feedstocks. Defaults to "linux-64".
+        :param python:     The python version for which to load the feedstocks. Defaults to "3.10".
+        :param others:     A variant dictionary. E.g. {"blas_impl" : "openblas"} Defaults to None.
+        :param renderer:   Rendering engine to use to interpret YAML
 
-        Returns:
-            Rendered packages contained in aggregate (also available as aggregate packages attribute).
+        :returns:    Rendered packages contained in aggregate (also available as aggregate packages attribute).
         """
 
         if others is None:

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -189,12 +189,11 @@ FeedstockGitRepo = namedtuple("FeedstockGitRepo", ["name", "git_url", "branch", 
 class Aggregate:
     """An object to handle a repository of feedstocks.
 
-    Attributes:
-        local_path (Path): Aggregate path.
-        git_url (str): Aggregate git url.
-        git_branch (str): Aggregate git branch.
-        packages (dict[str,Package]): Rendered packages. (Populated after calling load_local_feedstocks.)
-        feedstocks (dict[str,Feedstock]): Feedstocks. (Populated after calling load_local_feedstocks.)
+    :ivar local_path: Aggregate path.
+    :ivar git_url: Aggregate git url.
+    :ivar git_branch: Aggregate git branch.
+    :ivar packages: Rendered packages. (Populated after calling load_local_feedstocks.)
+    :ivar feedstocks: Feedstocks. (Populated after calling load_local_feedstocks.)
     """
 
     def __init__(self, aggregate_path: str, manifest_path: Optional[str] = None):
@@ -397,8 +396,7 @@ class Aggregate:
     def package_to_feedstock_path(self) -> dict[str, str]:
         """Returns a mapping of package name to feedstock path.
 
-        Returns:
-            dict[str, str]: mapping of package name to feedstock path.
+        :returns: Mapping of package name to feedstock path.
         """
         package_to_feedstock = {}
         for name, package in self.packages.items():
@@ -408,8 +406,7 @@ class Aggregate:
     def _build_order(self) -> dict[str, Feedstock]:
         """Computes a feedstock build order.
 
-        Returns:
-            dict[str, Feedstock]: An ordered dictionary of Feedstock.
+        :returns: An ordered dictionary of Feedstock.
         """
         # feedstock build order
         feedstocks = {}

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -443,16 +443,14 @@ class Aggregate:
     ) -> dict[str, Feedstock]:
         """Creates a Feedstock builder order based on a list of leaf packages.
 
-        Args:
-            target_groups (list[str], optional): List of target groups.
-            target_feedstocks (list[str], optional): List of target feedstocks.
-            target_packages (list[str]): List of leaf package names.
-            drop_noarch (bool, optional): Whether to drop noarch packages. Defaults to False.
-            no_upstream (bool, optional): Whether to drop unspecified packages. Defaults to False.
-            walk_up_sections (tuple[str], optional): Walk up sections.
+        :param target_groups: List of target groups.
+        :param target_feedstocks: List of target feedstocks.
+        :param target_packages: List of leaf package names.
+        :param drop_noarch: Whether to drop noarch packages. Defaults to False.
+        :param no_upstream: Whether to drop unspecified packages. Defaults to False.
+        :param walk_up_sections: Walk up sections.
 
-        Returns:
-            dict[str, Feedstock]: An ordered dictionary of Feedstock.
+        :returns: An ordered dictionary of Feedstock.
         """
         if target_groups is None:
             target_groups = []
@@ -501,17 +499,15 @@ class Aggregate:
     ) -> dict[str, Feedstock]:
         """Creates a Feedstock builder order based on packages having target as a dependency.
 
-        Args:
-            target_groups (list[str], optional): List of target groups.
-            target_feedstocks (list[str], optional): List of target feedstocks.
-            target_packages (list[str], optional): List of target packages.
-            package_allowlist (list[str], optional): List of package names to consider. Defaults to [].
-            feedstock_blocklist (list[str], optional): List of feedstock names to exclude. Defaults to [].
-            drop_noarch (bool, optional): Whether to drop noarch packages. Defaults to False.
-            walk_up_sections (tuple[str], optional): Walk up sections
+        :param target_groups: List of target groups.
+        :param target_feedstocks: List of target feedstocks.
+        :param target_packages: List of target packages.
+        :param package_allowlist: List of package names to consider. Defaults to [].
+        :param feedstock_blocklist: List of feedstock names to exclude. Defaults to [].
+        :param drop_noarch: Whether to drop noarch packages. Defaults to False.
+        :param walk_up_sections: Walk up sections
 
-        Returns:
-            dict[str, Feedstock]: An ordered dictionary of Feedstock.
+        :returns: An ordered dictionary of Feedstock.
         """
         if target_groups is None:
             target_groups = []

--- a/percy/render/exceptions.py
+++ b/percy/render/exceptions.py
@@ -26,13 +26,16 @@ class RecipeError(Exception):
 
 
 class EmptyRecipe(RecipeError):
-    """Raised if the recipe file is empty"""
+    """
+    Raised if the recipe file is empty
+    """
 
     template = "is empty"
 
 
 class MissingMetaYaml(RecipeError):
-    """Raised when FileNotFoundError is encountered
+    """
+    Raised when FileNotFoundError is encountered
 
     self.item is NOT a Recipe but a str here
     """
@@ -41,12 +44,16 @@ class MissingMetaYaml(RecipeError):
 
 
 class JinjaRenderFailure(RecipeError):
-    """Raised on Jinja rendering problems"""
+    """
+    Raised on Jinja rendering problems
+    """
 
     template = "failed to render in Jinja2. Error was: %s"
 
 
 class YAMLRenderFailure(RecipeError):
-    """Raised on YAML parsing problems"""
+    """
+    Raised on YAML parsing problems
+    """
 
     template = "failed to load YAML. Error was: %s"

--- a/percy/render/recipe.py
+++ b/percy/render/recipe.py
@@ -197,7 +197,7 @@ class Recipe:
     @classmethod
     def from_file(
         cls,
-        recipe_fname: str,
+        recipe_fname: str | Path,
         variant_id: Optional[str] = None,
         variant: Optional[Variant] = None,
         return_exceptions: bool = False,

--- a/percy/render/recipe.py
+++ b/percy/render/recipe.py
@@ -34,7 +34,8 @@ class OpMode(Enum):
 
 
 class Recipe:
-    """Represents a recipe (meta.yaml) in editable form
+    """
+    Represents a recipe (meta.yaml) in editable form
 
     Using conda-build to render recipe is slow and a one-way
     process. We need to be able to load **and** save recipes, which is
@@ -128,12 +129,16 @@ class Recipe:
 
     @property
     def path(self):
-        """Full path to ``meta.yaml``"""
+        """
+        Full path to ``meta.yaml``
+        """
         return self.recipe_file
 
     @property
     def dir(self):
-        """Path to recipe folder"""
+        """
+        Path to recipe folder
+        """
         return self.recipe_dir
 
     def __str__(self) -> str:
@@ -143,7 +148,8 @@ class Recipe:
         return f'{self.__class__.__name__} "{self.recipe_dir}"'
 
     def _load_from_string(self, data: str) -> "Recipe":
-        """Load and `render` recipe contents from disk
+        """
+        Load and `render` recipe contents from disk
 
         Args:
             data (str): raw meta.yaml as string.
@@ -169,7 +175,8 @@ class Recipe:
         return_exceptions: bool = False,
         renderer: Optional[renderer_utils.RendererType] = None,
     ) -> "Recipe":
-        """Create new `Recipe` object from string
+        """
+        Create new `Recipe` object from string
 
         Args:
             recipe_text: A raw recipe as a string.
@@ -204,7 +211,8 @@ class Recipe:
         return_exceptions: bool = False,
         renderer: Optional[renderer_utils.RendererType] = None,
     ) -> "Recipe":
-        """Create new `Recipe` object from file
+        """
+        Create new `Recipe` object from file
 
         Args:
             recipe_fname: Path to recipe meta.yaml
@@ -239,16 +247,21 @@ class Recipe:
         return recipe
 
     def save(self):
-        """Save recipe dump to file"""
+        """
+        Save recipe dump to file
+        """
         with open(self.path, "w", encoding="utf-8") as fdes:
             fdes.write(self.dump())
 
     def _set_original(self) -> None:
-        """Store the current state of the recipe as "original" version"""
+        """
+        Store the current state of the recipe as "original" version
+        """
         self.orig = deepcopy(self)
 
     def is_modified(self) -> bool:
-        """Has recipe been modified.
+        """
+        Has recipe been modified.
 
         Returns:
             bool: True if recipe has been modified.
@@ -256,11 +269,14 @@ class Recipe:
         return self.meta_yaml != self.orig.meta_yaml
 
     def dump(self) -> str:
-        """Dump recipe content"""
+        """
+        Dump recipe content
+        """
         return "\n".join(self.meta_yaml) + "\n"
 
     def render(self) -> None:
-        """Convert recipe text into data structure
+        """
+        Convert recipe text into data structure
 
         - create jinja template from recipe content
         - render template
@@ -454,9 +470,9 @@ class Recipe:
     def _walk(self, path: str, noraise: bool = False) -> tuple[list[dict[str, Any]], list[str]]:
         """
         Given a path, traverses the recipe data structure.
-        :param path:    Path to traverse
+        :param path: Path to traverse
         :param noraise: (Optional) If set to true, causes an exception if a key is not found.
-        :return: Tuple containing a list of nodes and a list of keys associated with those nodes.
+        :returns: Tuple containing a list of nodes and a list of keys associated with those nodes.
         """
         nodes = [self.meta]
         keys: list[str] = []
@@ -479,7 +495,8 @@ class Recipe:
         return nodes, keys
 
     def get_raw_range(self, path: str) -> tuple[int, int, int, int]:
-        """Locate the position of a node in the YAML within the raw text
+        """
+        Locate the position of a node in the YAML within the raw text
 
         See also `get_raw()` if you want to get the content of the unparsed
         meta.yaml at a specific key.
@@ -529,7 +546,8 @@ class Recipe:
         return (start_row, start_col, end_row, end_col)
 
     def get_raw(self, path: str) -> str:
-        """Extracts the unparsed text for a node in the meta.yaml
+        """
+        Extracts the unparsed text for a node in the meta.yaml
 
         This may contain separators and other characters from
         the yaml!
@@ -557,7 +575,8 @@ class Recipe:
         return "\n".join(lines).strip()
 
     def get(self, path: str, default: Any = KeyError) -> Any:
-        """Get a value or section from the recipe
+        """
+        Get a value or section from the recipe
 
         >>> recipe.get('requirements/build')
         ['setuptools]
@@ -590,7 +609,8 @@ class Recipe:
         return res
 
     def contains(self, path: str, value: str, default: Any = KeyError) -> bool:
-        """Check if a value (string or list) contains a string
+        """
+        Check if a value (string or list) contains a string
         >>> recipe.contains('build/script', 'pip')
         True
         The **path** is a ``/`` separated list of dictionary keys to
@@ -633,10 +653,9 @@ class Recipe:
         provided to allow callers access to some of the newest features and
         capabilities.
 
-        :param callback:    Callback that provides a `RecipeParser` instance
-                            that can make modifications that will be reflected
-                            in the `Recipe` class.
-        :return: True if the recipe was modified. False otherwise.
+        :param callback: Callback that provides a `RecipeParser` instance that can make modifications that will be
+            reflected in the `Recipe` class.
+        :returns: True if the recipe was modified. False otherwise.
         """
         # Read in the file as a string. Remembering that `recipe` stores
         # data as a list.
@@ -663,7 +682,8 @@ class Recipe:
         evaluate_selectors: bool = True,
         op_mode: OpMode = OpMode.CLASSIC,
     ) -> bool:
-        """Patch the recipe given a set of operations.
+        """
+        Patch the recipe given a set of operations.
         Args:
             operations: operations to apply
             increment_build_number: automatically increment the build number of the operations result in changes
@@ -934,7 +954,8 @@ class Dep:
     """
 
     def __init__(self, raw_dep: str, path: str):
-        """A dependency
+        """
+        A dependency
 
         Args:
             raw_dep (str): A dependency string. E.g. "numpy <1.24"
@@ -963,7 +984,9 @@ class Dep:
 
 @dataclass
 class Package:
-    """A rendered package."""
+    """
+    A rendered package.
+    """
 
     recipe: Recipe = None
     name: str = None
@@ -982,7 +1005,8 @@ class Package:
     git_info: object = None
 
     def __getitem__(self, key: str) -> Any:
-        """Access this dataclass attributes through square brackets.
+        """
+        Access this dataclass attributes through square brackets.
 
         Args:
             key (str): An attribute name of this data class.
@@ -993,7 +1017,8 @@ class Package:
         return getattr(self, key)
 
     def get(self, key: str, default=None) -> Any:
-        """Access this dataclass attributes through a getter.
+        """
+        Access this dataclass attributes through a getter.
 
         Args:
             key (str): An attribute name of this data class.
@@ -1008,7 +1033,8 @@ class Package:
             return default
 
     def has_dep(self, section: str, pkg_name: str) -> bool:
-        """Returns true if the package is present in the given section.
+        """
+        Returns true if the package is present in the given section.
 
         Args:
             section (str): A section. E.g. "build", "host", "run", "run_constrained
@@ -1020,7 +1046,8 @@ class Package:
         return any(pkg_name.lower() == dep.pkg.lower() for dep in self[section])
 
     def merge_deps(self, other: "Package"):
-        """Merge dependency list of another Package object into this Package.
+        """
+        Merge dependency list of another Package object into this Package.
         This is especially useful to create an aggregate of multiple variants.
 
         Args:
@@ -1042,7 +1069,8 @@ def render(
     return_exceptions: bool = False,
     renderer: Optional[renderer_utils.RendererType] = None,
 ) -> list[Recipe]:
-    """Render a recipe
+    """
+    Render a recipe
 
     Args:
         recipe_path: Path to a recipe.
@@ -1084,7 +1112,8 @@ def render(
 
 
 def dump_render_results(render_results: list[Recipe], out: TextIO = sys.stdout) -> None:
-    """Dumps a list of rendered variants of a recipe.
+    """
+    Dumps a list of rendered variants of a recipe.
 
     Args:
         render_results (list[Recipe]): list of rendered variants.

--- a/percy/render/recipe.py
+++ b/percy/render/recipe.py
@@ -78,21 +78,19 @@ class Recipe:
     ):
         """Constructor
 
-        Args:
-            recipe_file: Path to meta.yaml
-            variant_id: configuration id
-            variant: Variant configuration
-            renderer: Rendering backend. Defaults to PYYAML.
-        Attributes:
-            recipe_file (Path): The recipe file
-            recipe_dir (Path): The recipe directory
-            variant_id (str): configuration id
-            selector_dict (Variant): Variant configuration
-            meta (dict[str, Any]): Rendered recipe in as a dictionary
-            skip (bool): Whether this variant is skipped.
-            packages (dict[str:Package]): Rendered Packages.
-            meta_yaml (list[str]): Lines of the raw recipe file
-            orig (Recipe): Original recipe before modifications
+        :param recipe_file: Path to meta.yaml
+        :param variant_id: configuration id
+        :param variant: Variant configuration
+        :param renderer: Rendering backend. Defaults to PYYAML.
+        :ivar recipe_file: The recipe file
+        :ivar recipe_dir: The recipe directory
+        :ivar variant_id: configuration id
+        :ivar selector_dict: Variant configuration
+        :ivar meta: Rendered recipe in as a dictionary
+        :ivar skip: Whether this variant is skipped.
+        :ivar packages: Rendered Packages.
+        :ivar meta_yaml: Lines of the raw recipe file
+        :ivar orig: Original recipe before modifications
         """
         #: recipe dir
         if recipe_file:
@@ -151,14 +149,11 @@ class Recipe:
         """
         Load and `render` recipe contents from disk
 
-        Args:
-            data (str): raw meta.yaml as string.
+        :param data: raw meta.yaml as string.
 
-        Raises:
-            EmptyRecipe: The recipe is empty
+        :raises EmptyRecipe: The recipe is empty
 
-        Returns:
-            Recipe: This recipe object.
+        :returns: This recipe object.
         """
         self.meta_yaml = data.splitlines()
         if not self.meta_yaml:
@@ -178,19 +173,16 @@ class Recipe:
         """
         Create new `Recipe` object from string
 
-        Args:
-            recipe_text: A raw recipe as a string.
-            variant_id: Variant id
-            variant: Variant configuration.
-            return_exceptions: Whether to return exceptions. Defaults to False.
-            renderer: Rendering backend. Defaults to PYYAML.
+        :param recipe_text: A raw recipe as a string.
+        :param variant_id: Variant id
+        :param variant: Variant configuration.
+        :param return_exceptions: Whether to return exceptions. Defaults to False.
+        :param renderer: Rendering backend. Defaults to PYYAML.
 
-        Raises:
-            MissingMetaYaml: Missing meta.yaml
-            Exception: An exception
+        :raises MissingMetaYaml: Missing meta.yaml
+        :raises Exception: An exception
 
-        Returns:
-            Recipe: A Recipe object.
+        :returns: A Recipe object.
         """
         try:
             recipe = cls("", variant_id, variant, renderer)
@@ -214,19 +206,16 @@ class Recipe:
         """
         Create new `Recipe` object from file
 
-        Args:
-            recipe_fname: Path to recipe meta.yaml
-            variant_id: Variant id
-            variant: Variant configuration.
-            return_exceptions: Whether to return exceptions. Defaults to False.
-            renderer: Rendering backend. Defaults to PYYAML.
+        :param recipe_fname: Path to recipe meta.yaml
+        :param variant_id: Variant id
+        :param variant: Variant configuration.
+        :param return_exceptions: Whether to return exceptions. Defaults to False.
+        :param renderer: Rendering backend. Defaults to PYYAML.
 
-        Raises:
-            MissingMetaYaml: Missing meta.yaml
-            Exception: An exception
+        :raises MissingMetaYaml: Missing meta.yaml
+        :raises Exception: An exception
 
-        Returns:
-            Recipe: A Recipe object.
+        :returns: A Recipe object.
         """
         recipe_fname = Path(recipe_fname)
         recipe = cls(recipe_fname, variant_id, variant, renderer)
@@ -263,8 +252,7 @@ class Recipe:
         """
         Has recipe been modified.
 
-        Returns:
-            bool: True if recipe has been modified.
+        :returns: True if recipe has been modified.
         """
         return self.meta_yaml != self.orig.meta_yaml
 
@@ -501,11 +489,9 @@ class Recipe:
         See also `get_raw()` if you want to get the content of the unparsed
         meta.yaml at a specific key.
 
-        Args:
-          path: The "path" to the node. Use numbers for lists ('source/1/url')
+        :param path: The "path" to the node. Use numbers for lists ('source/1/url')
 
-        Returns:
-          a tuple of first_row, first_column, last_row, last_column
+        :returns: A tuple of first_row, first_column, last_row, last_column
         """
         if not path or self.renderer != renderer_utils.RendererType.RUAMEL:
             if self.meta_yaml:
@@ -552,14 +538,10 @@ class Recipe:
         This may contain separators and other characters from
         the yaml!
 
-        Args:
-          path: Slash-separated path to the node. Numbers can be used
-                to access indices in lists. A number '0' is ignored if
-                the node is a dict (so 'source/0/url' will work even if
-                there is only one url).
+        :param path: Slash-separated path to the node. Numbers can be used to access indices in lists. A number '0' is
+            ignored if the node is a dict (so 'source/0/url' will work even if there is only one url).
 
-        Returns:
-          Extracted raw text
+        :returns: Extracted raw text
         """
         start_row, start_col, end_row, end_col = self.get_raw_range(path)
         if start_row == end_row:
@@ -590,12 +572,9 @@ class Recipe:
         I.e., `source/0/url` will always get the first url, whether or
         not the source section is a list.
 
-        Args:
-          path: Path through YAML
-          default: If not KeyError, this value will be returned
-                   if the path does not exist in the recipe
-        Raises:
-          KeyError if no default given and the path does not exist.
+        :param path: Path through YAML
+        :param default: If not KeyError, this value will be returned if the path does not exist in the recipe
+        :raises KeyError: If no default given and the path does not exist.
         """
         try:
             nodes, _ = self._walk(path)
@@ -619,15 +598,11 @@ class Recipe:
         element in a list or the contents directly if there is no list.
         I.e., `source/0/url` will always get the first url, whether or
         not the source section is a list.
-        Args:
-            path: Path through YAML
-            value: The string to match
-            default: If not KeyError, this value will be returned
-                    if the path does not exist in the recipe
-        Returns:
-            Value match (bool).
-        Raises:
-            KeyError if no default given and the path does not exist.
+        :param path: Path through YAML
+        :param value: The string to match
+        :param default: If not KeyError, this value will be returned if the path does not exist in the recipe
+        :raises KeyError: If no default given and the path does not exist.
+        :returns: True if the value matches. False otherwise.
         """
         res = self.get(path, default)
         if isinstance(res, str):
@@ -684,13 +659,11 @@ class Recipe:
     ) -> bool:
         """
         Patch the recipe given a set of operations.
-        Args:
-            operations: operations to apply
-            increment_build_number: automatically increment the build number of the operations result in changes
-            evaluate_selectors: don't evaluate selectors when applying operations
-            op_mode: selects which operational mode to perform patches with
-        Returns:
-            True if recipe was patched. (bool).
+        :param operations: operations to apply
+        :param increment_build_number: automatically increment the build number of the operations result in changes
+        :param evaluate_selectors: don't evaluate selectors when applying operations
+        :param op_mode: selects which operational mode to perform patches with
+        :returns: True if recipe was patched.
         """
         # Early-escape the parse-tree operational mode. Allows us to A/B test
         # and use the newer parse tree work.
@@ -748,9 +721,8 @@ class Recipe:
     def _patch(self, operation: JsonPatchType, evaluate_selectors: bool) -> None:
         """
         Helper function that performs a single patch operation
-        Args:
-            operation: operation to apply
-            evaluate_selectors: don't evaluate selectors when applying operations
+        :param operation: operation to apply
+        :param evaluate_selectors: don't evaluate selectors when applying operations
         """
         # read operation parameters
         op = operation["op"]
@@ -957,15 +929,13 @@ class Dep:
         """
         A dependency
 
-        Args:
-            raw_dep (str): A dependency string. E.g. "numpy <1.24"
-            path (str): Path in the recipe. E.g. outputs/1/requirements/run
+        :param raw_dep: A dependency string. E.g. "numpy <1.24"
+        :param path: Path in the recipe. E.g. outputs/1/requirements/run
 
-        Attributes:
-            raw_dep (str): A dependency string. E.g. "numpy <1.24"
-            pkg (str): The package part. E.g. "numpy"
-            variable (str): The constraint part. E.g. "<1.24"
-            path (str): Path in the recipe. E.g. outputs/1/requirements/run
+        :var raw_dep: A dependency string. E.g. "numpy <1.24"
+        :var pkg: The package part. E.g. "numpy"
+        :var variable: The constraint part. E.g. "<1.24"
+        :var path: Path in the recipe. E.g. outputs/1/requirements/run
         """
         self.raw_dep = str(raw_dep)
         splits = re.split(r"[\s<=>]", self.raw_dep, 1)
@@ -1008,24 +978,20 @@ class Package:
         """
         Access this dataclass attributes through square brackets.
 
-        Args:
-            key (str): An attribute name of this data class.
+        :param key: An attribute name of this data class.
 
-        Returns:
-            Any: The value of the attribute.
+        :returns: The value of the attribute.
         """
         return getattr(self, key)
 
-    def get(self, key: str, default=None) -> Any:
+    def get(self, key: str, default: Optional[Any] = None) -> Any:
         """
         Access this dataclass attributes through a getter.
 
-        Args:
-            key (str): An attribute name of this data class.
-            default (_type_, optional): Default value. Defaults to None.
+        :param key: An attribute name of this data class.
+        :param default: Default value. Defaults to None.
 
-        Returns:
-            Any: The value of the attribute.
+        :returns: The value of the attribute.
         """
         try:
             return getattr(self, key, default)
@@ -1036,12 +1002,10 @@ class Package:
         """
         Returns true if the package is present in the given section.
 
-        Args:
-            section (str): A section. E.g. "build", "host", "run", "run_constrained
-            pkg_name (str): A package name.
+        :param section: A section. E.g. "build", "host", "run", "run_constrained
+        :param pkg_name: A package name.
 
-        Returns:
-            bool: True if the package is present in the given section.
+        :returns: True if the package is present in the given section.
         """
         return any(pkg_name.lower() == dep.pkg.lower() for dep in self[section])
 
@@ -1050,8 +1014,7 @@ class Package:
         Merge dependency list of another Package object into this Package.
         This is especially useful to create an aggregate of multiple variants.
 
-        Args:
-            other (Package): The other Package.
+        :param other: The other Package.
         """
         self.build.update(other.build)
         self.host.update(other.host)
@@ -1072,16 +1035,14 @@ def render(
     """
     Render a recipe
 
-    Args:
-        recipe_path: Path to a recipe.
-        subdir: A list of subdir to render for. E.g. ["linux-64", "win-64"]. Defaults to None to render all subdirs.
-        python: A list of python version to render for. E.g. ["3.10", "3.11"]. Defaults to None to render all python.
-        others: Additional variants configuration. E.g. {"blas_impl" : "openblas"} Defaults to None.
-        return_exceptions: Whether to handle errors as exceptions. Defaults to False.
-        renderer: Rendering backend. Defaults to PYYAML.
+    :param recipe_path: Path to a recipe.
+    :param subdir: A list of subdir to render for. E.g. ["linux-64", "win-64"]. Defaults to None to render all subdirs.
+    :param python: A list of python version to render for. E.g. ["3.10", "3.11"]. Defaults to None to render all python.
+    :param others: Additional variants configuration. E.g. {"blas_impl" : "openblas"} Defaults to None.
+    :param return_exceptions: Whether to handle errors as exceptions. Defaults to False.
+    :param renderer: Rendering backend. Defaults to PYYAML.
 
-    Returns:
-        A list of rendered Recipe, one per variant.
+    :returns: A list of rendered Recipe, one per variant.
     """
 
     # gather all possible variants
@@ -1115,9 +1076,7 @@ def dump_render_results(render_results: list[Recipe], out: TextIO = sys.stdout) 
     """
     Dumps a list of rendered variants of a recipe.
 
-    Args:
-        render_results (list[Recipe]): list of rendered variants.
-        out (TextIO, optional): Output stream. Defaults to sys.stdout.
-
+    :param render_results: list of rendered variants.
+    :param out: Output stream. Defaults to sys.stdout.
     """
     dumper.dump_render_results(render_results, out)

--- a/percy/render/variants.py
+++ b/percy/render/variants.py
@@ -48,13 +48,12 @@ def _find_config_files(
         4. recipe config files (see ${RECIPE_DIR}/conda_build_config.yaml)
         5. additional config files (see config.variant_config_files)
 
-    .. note::
-        Order determines clobbering with later files clobbering earlier ones.
+    .. note:: Order determines clobbering with later files clobbering earlier ones.
 
-    :param metadata_or_path:        The metadata or path within which to find recipe config files
-    :param variant_config_files:    List of config files containing variant info
-    :param exclusive_config_files:  List of config files containing exclusive info
-    :return: List of config files
+    :param metadata_or_path: The metadata or path within which to find recipe config files
+    :param variant_config_files: List of config files containing variant info
+    :param exclusive_config_files: List of config files containing exclusive info
+    :returns: List of config files
     """
 
     def resolve(p):
@@ -118,7 +117,9 @@ class CBCRenderError(Exception):
 
 # TODO Future: nearly identical to _renderer.py::apply_selector
 def _apply_selector(data, selector_dict):
-    """Apply selectors # [...]"""
+    """
+    Apply selectors # [...]
+    """
     updated_data = []
     for line in data.splitlines():
         if (match := re.search(r"^(\s*)#.*$", line)) is not None:
@@ -145,7 +146,8 @@ def read_conda_build_config(
     variant_config_files: Optional[list[str]] = None,
     exclusive_config_files: Optional[list[str]] = None,
 ) -> list[tuple[str, Variant]]:
-    """Read conda build config into a list of variants.
+    """
+    Read conda build config into a list of variants.
 
     Args:
         recipe_path: Path to a recipe meta.yaml file.

--- a/percy/render/variants.py
+++ b/percy/render/variants.py
@@ -149,19 +149,14 @@ def read_conda_build_config(
     """
     Read conda build config into a list of variants.
 
-    Args:
-        recipe_path: Path to a recipe meta.yaml file.
-        subdir: A list of subdir to render for. E.g. ["linux-64", "win-64"]. Defaults to None to render all subdirs.
-        python: A list of python version to render for. E.g. ["3.10", "3.11"]. Defaults to None to render all python.
-        others: Additional variants configuration. E.g. {"blas_impl" : "openblas"} Defaults to None.
-        variant_config_files: Additional cbc files to use. Defaults to [].
-        exclusive_config_files: If specified, only use these cbc files. Defaults to [].
+    :param recipe_path: Path to a recipe meta.yaml file.
+    :param subdir: A list of subdir to render for. E.g. ["linux-64", "win-64"]. Defaults to None to render all subdirs.
+    :param python: A list of python version to render for. E.g. ["3.10", "3.11"]. Defaults to None to render all python.
+    :param others: Additional variants configuration. E.g. {"blas_impl" : "openblas"} Defaults to None.
+    :param variant_config_files: Additional cbc files to use. Defaults to [].
+    :param exclusive_config_files: If specified, only use these cbc files. Defaults to [].
 
-    Raises:
-        CBCRenderError: Failed to render cbc file.
-
-    Returns:
-        A list of tuples, where the first value is a variant id and the second value a variant dictionary.
+    :returns: A list of tuples, where the first value is a variant id and the second value a variant dictionary.
     """
     if variant_config_files is None:
         variant_config_files = []

--- a/percy/repodata/repodata.py
+++ b/percy/repodata/repodata.py
@@ -15,7 +15,8 @@ from percy.render.recipe import Package
 
 
 def get_latest_package_list(subdir: str = "linux-64", merge_noarch: bool = True) -> dict[str, dict]:
-    """Get latest packages on defaults
+    """
+    Get latest packages on defaults
 
     Args:
         subdir (str, optional): The subdirectory. Defaults to "linux-64".
@@ -95,7 +96,8 @@ def get_latest_package_list(subdir: str = "linux-64", merge_noarch: bool = True)
 
 
 def compare_package_with_defaults(package: Package, defaults_pkgs: dict[str, dict]) -> dict:
-    """Compare a local package with its latest version on defaults
+    """
+    Compare a local package with its latest version on defaults
 
     Args:
         package (Package): Local package

--- a/percy/repodata/repodata.py
+++ b/percy/repodata/repodata.py
@@ -18,15 +18,10 @@ def get_latest_package_list(subdir: str = "linux-64", merge_noarch: bool = True)
     """
     Get latest packages on defaults
 
-    Args:
-        subdir (str, optional): The subdirectory. Defaults to "linux-64".
-        merge_noarch (bool, optional): Include noarch versions. Defaults to True.
+    :param subdir: The subdirectory. Defaults to "linux-64".
+    :param merge_noarch: Include noarch versions. Defaults to True.
 
-    Raises:
-        requests.HTTPError: Failed to retrieve repodata
-
-    Returns:
-        dict[str,dict]: { pkg_name : { version, build_number, noarch } }
+    :returns: { pkg_name : { version, build_number, noarch } }
     """
 
     session = requests.Session()
@@ -99,12 +94,10 @@ def compare_package_with_defaults(package: Package, defaults_pkgs: dict[str, dic
     """
     Compare a local package with its latest version on defaults
 
-    Args:
-        package (Package): Local package
-        defaults_pkgs (dict[str,dict]): defaults data
+    :param package: Local package
+    :param defaults_pkgs: defaults data
 
-    Returns:
-        dict: comparison result
+    :returns: Comparison result
     """
     result = None
     try:

--- a/percy/tests/test_recipe_parser.py
+++ b/percy/tests/test_recipe_parser.py
@@ -25,8 +25,8 @@ SIMPLE_DESCRIPTION: Final[
 def load_file(file: Path | str) -> str:
     """
     Loads a file into a single string
-    :param file:    Filename of the file to read
-    :return: Text from the file
+    :param file: Filename of the file to read
+    :returns: Text from the file
     """
     with open(Path(file), "r", encoding="utf-8") as f:
         return f.read()
@@ -35,8 +35,8 @@ def load_file(file: Path | str) -> str:
 def load_recipe(file_name: str) -> RecipeParser:
     """
     Convenience function that simplifies initializing a recipe parser.
-    :param file_name:   File name of the test recipe to load
-    :return: RecipeParser instance, based on the file
+    :param file_name: File name of the test recipe to load
+    :returns: RecipeParser instance, based on the file
     """
     recipe = load_file(f"{TEST_FILES_PATH}/{file_name}")
     return RecipeParser(recipe)


### PR DESCRIPTION
This was done by
- Manually searching for Google-formatted docs
- Manually converting Google-formatted docs
- Running the new `format-docs` `make` directive which auto-formats Sphnix docs. This requires a tool not currently available in `defaults`, so I manually installed it with `pip` and made a note in the `Makefile`

If this gets merged and approved, I plan to do something similar for
- `anaconda-linter`
- `perseverance-scripts`
- `anaconda-packaging-utls`
The later two projects should already be exclusively using Sphinx notation, so those should be strictly auto-formatting PRs


NOTE:
There is one bug fix in here. I noticed some files were transitively importing `RendererType` from the original source file. So I went ahead and fixed that issue as well.

I also still cannot find a way to have `pylint` enforce this style.