### PR TITLE
Adds test cases around `commands/` directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 omit =
     percy/tests/*
+    percy/examples/*

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,0 +1,6 @@
+# This surpresses deprecation `pytest` warnings related to using `conda.*` packages.
+# TODO Future: remove/upgrade deprecated packages
+[pytest]
+filterwarnings =
+    ignore:conda.* is pending deprecation:PendingDeprecationWarning
+    ignore:conda.* is deprecated:DeprecationWarning

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ export PRINT_HELP_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 # For now, most tools only run on new files, not the entire project.
-LINTER_FILES := percy/parser/*.py scripts/*.py
+MYPY_FILES := percy/commands/*.py percy/parser/*.py percy/render/*.py percy/repodata/*.py scripts/*.py
 
 clean: clean-cov clean-build clean-env clean-pyc clean-test clean-other ## remove all build, test, coverage and Python artifacts
 
@@ -98,7 +98,7 @@ test-debug:		## runs test cases with debugging info enabled
 	$(PYTHON3) -m pytest -n auto -vv --capture=no percy/tests/
 
 test-cov:		## checks test coverage requirements
-	$(PYTHON3) -m pytest -n auto --cov-config=.coveragerc --cov=percy percy/tests/ --cov-fail-under=20 --cov-report term-missing
+	$(PYTHON3) -m pytest -n auto --cov-config=.coveragerc --cov=percy percy/tests/ --cov-fail-under=45 --cov-report term-missing
 
 lint:			## runs the linter against the project
 	pylint --rcfile=.pylintrc percy
@@ -111,4 +111,4 @@ format-docs:	## runs the docstring auto-formatter. Note this requires manually i
 	docconvert --in-place --config .docconvert.json percy
 
 analyze:		## runs static analyzer on the project
-	mypy --config-file=.mypy.ini --cache-dir=/dev/null $(LINTER_FILES)
+	mypy --config-file=.mypy.ini --cache-dir=/dev/null $(MYPY_FILES)

--- a/percy/tests/commands/test_aggregate_cli.py
+++ b/percy/tests/commands/test_aggregate_cli.py
@@ -1,0 +1,22 @@
+"""
+File:           test_aggregate_cli.py
+Description:    Tests the `aggregate` CLI
+"""
+from click.testing import CliRunner
+
+from percy.commands.aggregate import aggregate
+
+
+def test_usage() -> None:
+    """
+    Ensure failure to provide a sub-command results in rendering the help menu
+    """
+    runner = CliRunner()
+    # No commands are provided
+    result = runner.invoke(aggregate, [])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")
+    # Help is specified
+    result = runner.invoke(aggregate, ["--help"])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")

--- a/percy/tests/commands/test_main_cli.py
+++ b/percy/tests/commands/test_main_cli.py
@@ -1,0 +1,22 @@
+"""
+File:           test_main_cli.py
+Description:    Tests the primary CLI interface, found under `percy.commands.main`
+"""
+from click.testing import CliRunner
+
+from percy.commands.main import cli
+
+
+def test_usage() -> None:
+    """
+    Ensure failure to provide a sub-command results in rendering the help menu
+    """
+    runner = CliRunner()
+    # No commands are provided
+    result = runner.invoke(cli, [])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")
+    # Help is specified
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")

--- a/percy/tests/commands/test_recipe_cli.py
+++ b/percy/tests/commands/test_recipe_cli.py
@@ -1,0 +1,22 @@
+"""
+File:           test_recipe_cli.py
+Description:    Tests the recipe CLI
+"""
+from click.testing import CliRunner
+
+from percy.commands.recipe import recipe
+
+
+def test_usage() -> None:
+    """
+    Ensure failure to provide a sub-command results in rendering the help menu
+    """
+    runner = CliRunner()
+    # No commands are provided
+    result = runner.invoke(recipe, [])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")
+    # Help is specified
+    result = runner.invoke(recipe, ["--help"])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -1,5 +1,5 @@
 """
-File:           test_py
+File:           test_recipe_parser.py
 Description:    Unit tests for the recipe parser class and tools
 """
 from __future__ import annotations


### PR DESCRIPTION
- Adds basic tests around `percy`'s CLI tools. This at least acts as a smoke test, to ensure the CLIs can at least run "to some degree"
- Moves existing test into an appropriate folder
- Increases test coverage requirement

Also ignores `examples/` directory
- Example projects are no longer considered for test-coverage statistics.
  - This follows our previous decision that the `examples/` directory does not need to be considered for linting
- This does not fully enable the static analyzer