### PR TITLE
The `parser/` module now pass our `mypy` rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
-# For now, most tools only run on new files, not the entire project.
+# Include everything EXCEPT the `examples` directory.
 MYPY_FILES := percy/commands/*.py percy/parser/*.py percy/render/*.py percy/repodata/*.py scripts/*.py
 
 clean: clean-cov clean-build clean-env clean-pyc clean-test clean-other ## remove all build, test, coverage and Python artifacts

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,8 +17,11 @@ dependencies:
   - conda
   - jinja2
   - pyyaml
+  - types-pyyaml
   - requests
+  - types-requests
   - ruamel.yaml
   - conda-build
   - jsonschema
+  - types-jsonschema
   - pre-commit

--- a/percy/parser/_node.py
+++ b/percy/parser/_node.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Optional
 
 from percy.parser._types import ROOT_NODE_VALUE
-from percy.parser.types import Primitives
+from percy.parser.types import NodeValue, SentinelType
 
 
 class Node:
@@ -26,11 +26,11 @@ class Node:
 
     # Sentinel used to discern a `null` in the YAML file and a defaulted, unset value. For example, comment-only lines
     # should always be set to the `_sentinel` object.
-    _sentinel = object()
+    _sentinel = SentinelType()
 
     def __init__(
         self,
-        value: Primitives = _sentinel,
+        value: NodeValue | SentinelType = _sentinel,
         comment: str = "",
         children: Optional[list["Node"]] = None,
         list_member_flag: bool = False,
@@ -98,7 +98,7 @@ class Node:
             return f"<Comment: {self.comment}>"
         if self.is_collection_element():
             return "<Collection Node>"
-        return self.value
+        return str(self.value)
 
     def is_leaf(self) -> bool:
         """
@@ -119,7 +119,7 @@ class Node:
         Indicates if a line contains only a comment. When rendered, this will be a comment only-line.
         :returns: True if the node represents only a comment. False otherwise.
         """
-        return self.value == Node._sentinel and self.comment and not self.children
+        return self.value == Node._sentinel and bool(self.comment) and not self.children
 
     def is_empty_key(self) -> bool:
         """
@@ -153,4 +153,4 @@ class Node:
         value itself BUT it contains children that do.
         :returns: True if the noe represents an element that is a collection. False otherwise.
         """
-        return self.value == Node._sentinel and self.list_member_flag and len(self.children)
+        return self.value == Node._sentinel and self.list_member_flag and bool(self.children)

--- a/percy/parser/_traverse.py
+++ b/percy/parser/_traverse.py
@@ -126,9 +126,9 @@ def traverse_with_index(root: Node, path: StrStack) -> tuple[Optional[Node], int
         - If the node is a member of a list, the index returned will be >= 0.
     """
     if len(path) == 0:
-        return None
+        return None, -1
 
-    node: Node
+    node: Optional[Node]
     node_idx: int = -1
     # Pre-determine if the path is targeting a list position. Patching only applies on the last index provided.
     if path[0].isdigit():
@@ -142,7 +142,7 @@ def traverse_with_index(root: Node, path: StrStack) -> tuple[Optional[Node], int
 
 def traverse_all(
     node: Optional[Node],
-    func: Callable[[Node, list[str]], None],
+    func: Callable[[Node, StrStack], None],
     path: Optional[StrStackImmutable] = None,
     idx_num: int = 0,
 ) -> None:
@@ -169,7 +169,7 @@ def traverse_all(
         path = (str(idx_num),) + path
     # Leafs do not contain their values in the path, unless the leaf is an empty key (as the key is part of the path).
     elif node.is_empty_key() or not node.is_leaf():
-        path = (node.value,) + path
+        path = (str(node.value),) + path
     func(node, list(path))
     # Used for paths that contain lists of items
     mapping = remap_child_indices_phys_to_virt(node.children)

--- a/percy/parser/_types.py
+++ b/percy/parser/_types.py
@@ -5,20 +5,16 @@ Description:    Provides private types, type aliases, constants, and small class
 from __future__ import annotations
 
 import re
-from typing import Callable, Final, Optional
+from typing import Final
 
 import yaml
-
-from percy.parser.types import JsonType
 
 #### Private Types (Not to be used external to the `parser` module) ####
 
 # Type alias for a list of strings treated as a Pythonic stack
 StrStack = list[str]
 # Type alias for a `StrStack` that must be immutable. Useful for some recursive operations.
-StrStackImmutable = tuple[str]
-# Type alias for a table that maps operations to functions.
-OpsTable = dict[str, Callable[[str, StrStack, Optional[JsonType]], bool]]
+StrStackImmutable = tuple[str, ...]
 
 #### Private Constants (Not to be used external to the `parser` module) ####
 
@@ -39,7 +35,7 @@ class ForceIndentDumper(yaml.Dumper):
     Adapted from: https://stackoverflow.com/questions/25108581/python-yaml-dump-bad-indentation
     """
 
-    def increase_indent(self, flow=False, indentless=False):  # pylint: disable=unused-argument
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:  # pylint: disable=unused-argument
         return super().increase_indent(flow, False)
 
 

--- a/percy/parser/types.py
+++ b/percy/parser/types.py
@@ -4,28 +4,49 @@ Description:    Provides public types, type aliases, constants, and small classe
 """
 from __future__ import annotations
 
-from typing import Any, Final, Mapping, Union
+from typing import Final, Hashable, TypeVar, Union
 
 #### Types ####
 
 # Base types that can store value
 Primitives = Union[str, int, float, bool, None]
 # Same primitives, as a tuple. Used with `isinstance()`
-PRIMITIVES_TUPLE: Final[tuple] = (str, int, float, bool, type(None))
+PRIMITIVES_TUPLE: Final[tuple[type[str], type[int], type[float], type[bool], type[None]]] = (
+    str,
+    int,
+    float,
+    bool,
+    type(None),
+)
 
 # Type that represents a JSON-like type
 JsonType = Union[dict[str, "JsonType"], list["JsonType"], Primitives]
 
 # Type that represents a JSON patch payload
 JsonPatchType = dict[str, JsonType]
+
+# Types that build up to types used in `jsonschema`s
+SchemaPrimitives = Union[str, int, bool, None]
+SchemaDetails = Union[dict[str, "SchemaDetails"], list["SchemaDetails"], SchemaPrimitives]
 # Type for a schema object used by the `jsonschema` library
-SchemaType = Mapping[str, Any]  # type: ignore[misc]
+SchemaType = dict[str, SchemaDetails]
+
+# Generic, hashable type
+H = TypeVar("H", bound=Hashable)
+
+# Nodes can store a single value or a list of strings (for multiline-string nodes)
+NodeValue = Primitives | list[str]
+
+
+# All sentinel values used in this module should be constructed with this class, for typing purposes.
+class SentinelType:
+    pass
 
 
 #### Constants ####
 
 # Indicates how many spaces are in a level of indentation
-TAB_SPACE_COUNT: Final[str] = 2
+TAB_SPACE_COUNT: Final[int] = 2
 TAB_AS_SPACES: Final[str] = " " * TAB_SPACE_COUNT
 
 # Schema validator for JSON patching


### PR DESCRIPTION
- The goal is to start getting `percy` ready for passing our static analyzer rules
- Makes patch-switching logic more static-analyzer friendly
  - Ditched a look-up table of callbacks for a series of if statements
- Disables one of the rendering functions from type-checking due to the nature of the complex type conversions

Here's a rough guide to how this was accomplished:
- Most complex fixes are handled with `cast()` statements. These are performed savely as the necessary checks to narrow the type are too complex for the static analyzer
- Some types can be narrowed with `TypeGuards`, although this is limited. Perhaps in the future we can remove some `cast()` calls by sub-classing our `Node` structure instead of using `is_<attribute>()` functions. As best as I can tell, we can't currently use `TypeGuards()` in those check functions
- Very few statements use `assert` for type narrowing. These are done ONLY when the line above clearly indicates the type that has been set (but the static analyzer can't pick up on that knowledge)