### PR TITLE
Prerequisites for improving the version-whitespace rule in anaconda-linter

### DIFF
--- a/percy/parser/_node.py
+++ b/percy/parser/_node.py
@@ -152,6 +152,6 @@ class Node:
         """
         Indicates if the node is a list member that contains other collection types. In other words, this node has no
         value itself BUT it contains children that do.
-        :returns: True if the noe represents an element that is a collection. False otherwise.
+        :returns: True if the node represents an element that is a collection. False otherwise.
         """
         return self.value == Node._sentinel and self.list_member_flag and bool(self.children)

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -851,14 +851,37 @@ class RecipeParser:
         """
         Given a path, determine if a selector exists on that line.
         :param path: Target path
+        :returns: True if the selector exists at that path. False otherwise.
         """
-        pass
+        path_stack = str_to_stack_path(path)
+        node = traverse(self._root, path_stack)
+        if node is None:
+            return False
+        return bool(Regex.SELECTOR.search(node.comment))
 
-    def get_selector_at_path(self, path: str) -> str:
+    def get_selector_at_path(self, path: str, default: str | SentinelType = _sentinel) -> str:
         """
-        Given a path, return the selector that exists on that line. If no selector exists, TODO
+        Given a path, return the selector that exists on that line.
+        :param path: Target path
+        :param default: (Optional) Default value to use if no selector is found.
+        :raises KeyError: If a selector is not found on the provided path AND no default has been specified.
+        :raises ValueError: If the default selector provided is malformed
+        :returns: Selector on the path provided
         """
-        pass
+        path_stack = str_to_stack_path(path)
+        node = traverse(self._root, path_stack)
+        if node is None:
+            raise KeyError(f"Path not found: {path}")
+
+        search_results = Regex.SELECTOR.search(node.comment)
+        if not search_results:
+            # Use `default` case
+            if default != RecipeParser._sentinel and not isinstance(default, SentinelType):
+                if not Regex.SELECTOR.match(default):
+                    raise ValueError(f"Invalid selector provided: {default}")
+                return default
+            raise KeyError(f"Selector not found at path: {path}")
+        return search_results.group(0)
 
     def add_selector(self, path: str, selector: str, mode: SelectorConflictMode = SelectorConflictMode.REPLACE) -> None:
         """

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -710,7 +710,7 @@ class RecipeParser:
         :returns: A list of all paths in a recipe file that point to dependencies.
         """
         paths: list[str] = []
-        req_sections: Final[list[str]] = ["build", "host", "run", "run_constrained", "run_exports"]
+        req_sections: Final[list[str]] = ["build", "host", "run", "run_constrained"]
 
         # Convenience function that reduces repeated logic between regular and multi-output recipes
         def _scan_requirements(path_prefix: str = "") -> None:

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -715,7 +715,7 @@ class RecipeParser:
         # Convenience function that reduces repeated logic between regular and multi-output recipes
         def _scan_requirements(path_prefix: str = "") -> None:
             for section in req_sections:
-                section_path: Final[str] = f"{path_prefix}/requirements/{section}"
+                section_path = f"{path_prefix}/requirements/{section}"
                 # Relying on `get_value()` ensures that we will only examine literal values and ignore comments
                 # in-between dependencies.
                 dependencies = cast(list[str], self.get_value(section_path, []))

--- a/percy/tests/test_aux_files/simple-recipe_comment_in_requirements.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_comment_in_requirements.yaml
@@ -1,0 +1,55 @@
+{% set zz_non_alpha_first = 42 %}
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}  # [unix]
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  is_true: true
+
+# Comment above a top-level structure
+requirements:
+  empty_field1:
+  host:
+    - setuptools  # [unix]
+    # This comment is to test indexing
+    - fakereq  # [unix] selector with comment
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
+  run:
+    # Testing indexing with comments
+    - python  # not a selector
+  empty_field3:
+
+about:
+  summary: This is a small recipe for testing
+  description: |
+    This is a PEP '561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+
+multi_level:
+  list_1:
+    - foo
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - bat
+    - mat
+  list_3:
+    - ls
+    - sl
+    - cowsay
+
+test_var_usage:
+  foo: {{ version }}
+  bar:
+    - baz
+    - {{ zz_non_alpha_first }}
+    - blah
+    - This {{ name }} is silly
+    - last


### PR DESCRIPTION
These changes are required to improve an existing (and crashing) auto-fix rule in the `anaconda-linter` project.

- Adds 4 new functions to the `percy` parser project.
  - 2 for handling dependencies
  - 2 for dealing with selectors
- Adds unit tests
- Also fixes a previously unknown bug. In some cases, we were returning a primitive value instead of a list containing 1 primitive value. A regression test was added to guard ourselves in the future.