### PR TITLE
First-pass at a recipe conversion function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,19 +51,15 @@ repos:
   hooks:
   - id: pylint
     args: ["--rcfile=.pylintrc"]
-# TODO re-enable the static analyzer, when the rest of the dev tools have
-# stabilized.
-#- repo: https://github.com/pre-commit/mirrors-mypy
-#  rev: v1.6.1
-#  hooks:
-#  - id: mypy
-#    # `mypy` is run as a system script to ensure that it is checking against
-#    # the libraries we have installed to the environment.
-#    language: system
-#    args: [--config-file=.mypy.ini, "--cache-dir=/dev/null"]
 # `pre-commit` no longer provides a hook for `pytest`, by design
 - repo: local
   hooks:
+  # TODO Future: enable `mypy` on the full project. `make analyze` only checks some modules.
+  - id: mypy
+    language: system
+    name: mypy-parser
+    pass_filenames: false
+    entry: make analyze
   - id: pytest
     language: system
     name: pytest

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,6 +1,5 @@
 # This surpresses deprecation `pytest` warnings related to using `conda.*` packages.
-# TODO Future: remove/upgrade deprecated packages
 [pytest]
 filterwarnings =
-    ignore:conda.* is pending deprecation:PendingDeprecationWarning
-    ignore:conda.* is deprecated:DeprecationWarning
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
-# Include everything EXCEPT the `examples` and `commands` directories.
-MYPY_FILES := percy/parser/*.py percy/render/*.py percy/repodata/*.py scripts/*.py
+# TODO fully enable on the project. For now, only enforce the `parser/` module, which has been built with the static
+# analyzer in mind.
+# Long-term: Include everything EXCEPT the `examples` and `commands` directories.
+MYPY_FILES := percy/parser/*.py # percy/render/*.py percy/repodata/*.py scripts/*.py
 
 clean: clean-cov clean-build clean-env clean-pyc clean-test clean-other ## remove all build, test, coverage and Python artifacts
 

--- a/percy/commands/convert.py
+++ b/percy/commands/convert.py
@@ -1,0 +1,69 @@
+"""
+File:           convert.py
+Description:    CLI for converting an old recipe file to the "new" format.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Final
+
+import click
+
+from percy.parser.recipe_parser import RecipeParser
+from percy.parser.types import MessageCategory, MessageTable
+
+# Required file name for the recipe, specified in CEP-13
+NEW_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
+
+
+def print_out(*args, **kwargs):
+    """
+    Convenience wrapper that prints to STDOUT
+    """
+    print(*args, file=sys.stdout, **kwargs)
+
+
+def print_err(*args, **kwargs):
+    """
+    Convenience wrapper that prints to STDERR
+    """
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def print_messages(category: MessageCategory, msg_tbl: MessageTable):
+    """
+    Convenience function for dumping a series of messages of a certain category
+    :param category: Category of messages to print
+    :param msg_tbl: `MessageTable` instance containing the messages to print
+    """
+    msgs: Final[list[str]] = msg_tbl.get_messages(category)
+    for msg in msgs:
+        print_err(f"[{category.upper()}]: {msg}")
+
+
+@click.command(short_help="Converts a `meta.yaml` formatted-recipe file to the new `recipe.yaml` format")
+@click.argument("file", type=click.File("r", encoding="utf-8"))
+@click.option("--output", "-o", type=click.Path(exists=False), default=None, help="File to dump a new recipe to.")
+def convert(file: click.File, output: click.Path) -> None:  # pylint: disable=redefined-outer-name
+    """
+    Recipe conversion CLI utility. By default, recipes print to STDOUT. Messages always print to STDERR.
+    """
+    recipe_content: Final[str] = file.read()
+
+    parser = RecipeParser(recipe_content)
+    result, msg_tbl = parser.render_to_new_recipe_format()
+
+    if output is None:
+        print_out(result)
+    else:
+        if not os.path.basename(output) == "recipe.yaml":
+            print_err("WARNING: File is not called `recipe.yaml`.")
+        with open(output, "w", encoding="utf-8") as fptr:
+            fptr.write(result)
+
+    summary: Final[str] = msg_tbl.get_totals_message()
+    if summary:
+        print_messages(MessageCategory.WARNING, msg_tbl)
+        print_messages(MessageCategory.ERROR, msg_tbl)
+        print_err(summary)

--- a/percy/commands/convert.py
+++ b/percy/commands/convert.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import sys
+from enum import IntEnum
 from typing import Final
 
 import click
@@ -15,6 +16,21 @@ from percy.parser.types import MessageCategory, MessageTable
 
 # Required file name for the recipe, specified in CEP-13
 NEW_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
+
+
+class ExitCode(IntEnum):
+    """
+    Error codes
+    """
+
+    SUCCESS = 0
+    CLICK_ERROR = 1  # Controlled by the `click` library
+    CLICK_USAGE = 2  # Controlled by the `click` library
+    # Errors are roughly ordered by increasing severity
+    RENDER_WARNINGS = 100
+    RENDER_ERRORS = 101
+    PARSE_EXCEPTION = 102
+    RENDER_EXCEPTION = 103
 
 
 def print_out(*args, **kwargs):
@@ -51,8 +67,22 @@ def convert(file: click.File, output: click.Path) -> None:  # pylint: disable=re
     """
     recipe_content: Final[str] = file.read()
 
-    parser = RecipeParser(recipe_content)
-    result, msg_tbl = parser.render_to_new_recipe_format()
+    parser: RecipeParser
+    try:
+        parser = RecipeParser(recipe_content)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print_err("An exception occurred while parsing the recipe file:")
+        print_err(e)
+        sys.exit(ExitCode.PARSE_EXCEPTION)
+
+    result: str
+    msg_tbl: MessageTable
+    try:
+        result, msg_tbl = parser.render_to_new_recipe_format()
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print_err("An exception occurred while converting to the new recipe file:")
+        print_err(e)
+        sys.exit(ExitCode.RENDER_EXCEPTION)
 
     if output is None:
         print_out(result)
@@ -62,8 +92,15 @@ def convert(file: click.File, output: click.Path) -> None:  # pylint: disable=re
         with open(output, "w", encoding="utf-8") as fptr:
             fptr.write(result)
 
-    summary: Final[str] = msg_tbl.get_totals_message()
-    if summary:
+    error_count: Final[int] = msg_tbl.get_message_count(MessageCategory.ERROR)
+    warn_count: Final[int] = msg_tbl.get_message_count(MessageCategory.WARNING)
+    if (error_count + warn_count) > 0:
         print_messages(MessageCategory.WARNING, msg_tbl)
         print_messages(MessageCategory.ERROR, msg_tbl)
-        print_err(summary)
+        print_err(msg_tbl.get_totals_message())
+        if error_count > 0:
+            sys.exit(ExitCode.RENDER_ERRORS)
+        if warn_count > 0:
+            sys.exit(ExitCode.RENDER_WARNINGS)
+
+    sys.exit(ExitCode.SUCCESS)

--- a/percy/commands/main.py
+++ b/percy/commands/main.py
@@ -9,6 +9,7 @@ import os
 import click
 
 from percy.commands.aggregate import aggregate
+from percy.commands.convert import convert
 from percy.commands.recipe import recipe
 
 
@@ -21,6 +22,7 @@ def cli() -> None:
 # add subcommands
 cli.add_command(recipe)
 cli.add_command(aggregate)
+cli.add_command(convert)
 
 
 @cli.command()

--- a/percy/parser/_traverse.py
+++ b/percy/parser/_traverse.py
@@ -4,10 +4,13 @@ Description:    Provides tree traversal functions only used by the parser.
 """
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable, Final, Optional
 
 from percy.parser._node import Node
 from percy.parser._types import ROOT_NODE_VALUE, StrStack, StrStackImmutable
+
+# Indicates an array index that is not valid
+INVALID_IDX: Final[int] = -1
 
 
 def remap_child_indices_virt_to_phys(children: list[Node]) -> list[int]:
@@ -128,11 +131,11 @@ def traverse_with_index(root: Node, path: StrStack) -> tuple[Optional[Node], int
         - If the node is a member of a list, the PHYSICAL index returned will be >= 0
     """
     if len(path) == 0:
-        return None, -1
+        return None, INVALID_IDX, INVALID_IDX
 
     node: Optional[Node]
-    virt_idx: int = -1
-    phys_idx: int = -1
+    virt_idx: int = INVALID_IDX
+    phys_idx: int = INVALID_IDX
     # Pre-determine if the path is targeting a list position. Patching only applies on the last index provided.
     if path[0].isdigit():
         # Find the index position of the target on the parent's list

--- a/percy/parser/_traverse.py
+++ b/percy/parser/_traverse.py
@@ -145,6 +145,11 @@ def traverse_with_index(root: Node, path: StrStack) -> tuple[Optional[Node], int
     if node is not None and virt_idx >= 0:
         phys_idx = remap_child_indices_virt_to_phys(node.children)[virt_idx]
 
+        # If the node in a list is a "Collection Element", we want return that node and not the parent that contains
+        # the list. Collection Nodes are abstract containers that will contain the rest of
+        if node.children[phys_idx].is_collection_element():
+            return node.children[phys_idx], INVALID_IDX, INVALID_IDX
+
     return node, virt_idx, phys_idx
 
 

--- a/percy/parser/_traverse.py
+++ b/percy/parser/_traverse.py
@@ -115,29 +115,34 @@ def traverse(node: Optional[Node], path: StrStack) -> Optional[Node]:
     return _traverse_recurse(node, path)
 
 
-def traverse_with_index(root: Node, path: StrStack) -> tuple[Optional[Node], int]:
+def traverse_with_index(root: Node, path: StrStack) -> tuple[Optional[Node], int, int]:
     """
     Given a path, return the node of interest OR the parent node with indexing information, if the node is in a list.
+
     :param root: Starting node of the tree/branch to traverse.
     :param path: Path, as a stack, that describes a location in the tree.
-    :returns: A tuple containing two items: - `Node` object if a node is found in the parse tree at that path. Otherwise
-        returns `None`. If the
-            path terminates in an index, the parent is returned with the index location.
-        - If the node is a member of a list, the index returned will be >= 0.
+    :returns: A tuple containing:
+        - `Node` object if a node is found in the parse tree at that path. Otherwise
+          returns `None`. If the path terminates in an index, the parent is returned with the index location.
+        - If the node is a member of a list, the VIRTUAL index returned will be >= 0
+        - If the node is a member of a list, the PHYSICAL index returned will be >= 0
     """
     if len(path) == 0:
         return None, -1
 
     node: Optional[Node]
-    node_idx: int = -1
+    virt_idx: int = -1
+    phys_idx: int = -1
     # Pre-determine if the path is targeting a list position. Patching only applies on the last index provided.
     if path[0].isdigit():
         # Find the index position of the target on the parent's list
-        node_idx = int(path.pop(0))
+        virt_idx = int(path.pop(0))
 
     node = traverse(root, path)
+    if node is not None and virt_idx >= 0:
+        phys_idx = remap_child_indices_virt_to_phys(node.children)[virt_idx]
 
-    return node, node_idx
+    return node, virt_idx, phys_idx
 
 
 def traverse_all(

--- a/percy/parser/_utils.py
+++ b/percy/parser/_utils.py
@@ -110,9 +110,10 @@ def stringify_yaml(val: NodeValue | SentinelType, multiline_flag: bool = False) 
         return "false"
     # Ensure string quote escaping if quote marks are present. Otherwise this has the unintended consequence of
     # quoting all YAML strings. Although not wrong, it does not follow our common practices. Quote escaping is not
-    # required for multiline strings. We do not escape quotes for Jinja value statements.
+    # required for multiline strings. We do not escape quotes for Jinja value statements. We make an exception for
+    # strings containing the NEW recipe format syntax, ${{ }}, which is valid YAML.
     if not multiline_flag and isinstance(val, str) and not Regex.JINJA_SUB.match(val):
-        if "'" in val or '"' in val:
+        if "${{" not in val and ("'" in val or '"' in val):
             # The PyYaml equivalent function injects newlines, hence why we abuse the JSON library to write our YAML
             return json.dumps(val)
     return val

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -623,6 +623,10 @@ class RecipeParser:
         # TODO: make more robust and don't assume `context` will be at the end of the list
         new_recipe._root.children.insert(0, new_recipe._root.children.pop(-1))
 
+        # Similarly, patch-in the new `schema_version` value to the top of the file
+        new_recipe.patch({"op": "add", "path": "/schema_version", "value": 1})
+        new_recipe._root.children.insert(0, new_recipe._root.children.pop(-1))
+
         # Swap all JINJA to use the new `${{ }}` format.
         jinja_sub_locations: Final[list[str]] = new_recipe.search(Regex.JINJA_SUB)
         for path in jinja_sub_locations:

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -15,6 +15,7 @@ Description:    Provides a class that takes text from a Jinja-formatted recipe f
 from __future__ import annotations
 
 import ast
+import copy
 import difflib
 import json
 import re
@@ -591,6 +592,31 @@ class RecipeParser:
             self._render_object_tree(child, replace_variables, data)
 
         return data
+
+    def render_to_new_recipe_format(self) -> str:
+        """
+        Takes the current recipe representation and renders it to the new format WITHOUT modifying the current recipe
+        state.
+
+        The "new" format is defined in the following CEPs:
+          - https://github.com/conda-incubator/ceps/blob/main/cep-13.md
+          - https://github.com/conda-incubator/ceps/blob/main/cep-14.md
+
+        (As of writing there is no official name other than "the new recipe format")
+        """
+        # Approach: In the event that we want to expand support later, this function should be implemented in terms
+        # of a `RecipeParser` tree. This will make it easier to build an upgrade-path, if we so choose to pursue one.
+        new_recipe: RecipeParser = copy.deepcopy(self)
+
+        # TODO convert the JINJA variable table to a `context` section
+
+        # TODO swap all JINJA to use the new `${{ }}` format
+
+        # TODO convert selectors into ternary statements or `if` blocks
+
+        # TODO handle changes made to the license path(s)
+
+        return new_recipe.render()
 
     ## YAML Access Functions ##
 

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -612,8 +612,11 @@ class RecipeParser:
         # is no development cost in utilizing tools we already must maintain.
         new_recipe: RecipeParser = RecipeParser(self.render())
 
-        # Convert the JINJA variable table to a `context` section
-        new_recipe.patch({"op": "add", "path": "/context", "value": new_recipe._vars_tbl})
+        # Convert the JINJA variable table to a `context` section. Empty tables still add the `context` section for
+        # future developers' convenience.
+        new_recipe.patch(
+            {"op": "add", "path": "/context", "value": new_recipe._vars_tbl if new_recipe._vars_tbl else None}
+        )
 
         # Hack: `add` has no concept of ordering and new fields are appended to the end. Logically, `context` should be
         # at the top of the file, so we'll force it to the front of root's child list.
@@ -628,6 +631,7 @@ class RecipeParser:
             if not isinstance(value, str):
                 continue
             value = value.replace("{{", "${{")
+            # TODO Fix: Inclusion of 's in `value` breaks `patch()`, breaking the `multi-output.yaml` test
             new_recipe.patch({"op": "replace", "path": path, "value": value})
 
         # Convert selectors into ternary statements or `if` blocks

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -844,6 +844,26 @@ class RecipeParser:
 
         return paths
 
+    @staticmethod
+    def append_to_path(base_path: str, ext_path: str) -> str:
+        """
+        Convenience function meant to be paired with `get_package_paths()` to generate extended paths. This handles
+        issues that arise when concatenating paths that do or do not include a trailing/leading `/` character. Most
+        notably, the root path `/` inherently contains a trailing `/`.
+        :param base_path: Base path, provided by `get_package_paths()`
+        :param ext_path: Path to append to the end of the `base_path`
+        :returns: A normalized path constructed by the two provided paths.
+        """
+        # Ensure the base path always ends in a `/`
+        if not base_path:
+            base_path = "/"
+        if base_path[-1] != "/":
+            base_path += "/"
+        # Ensure the extended path never starts with a `/`
+        if ext_path and ext_path[0] == "/":
+            ext_path = ext_path[1:]
+        return f"{base_path}{ext_path}"
+
     def get_dependency_paths(self) -> list[str]:
         """
         Convenience function that returns a list of all dependency lines in a recipe.

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -655,7 +655,6 @@ class RecipeParser:
                 )
                 continue
             value = value.replace("{{", "${{")
-            # TODO Fix: Inclusion of 's in `value` breaks `patch()`, breaking the `multi-output.yaml` test
             _patch_and_log({"op": "replace", "path": path, "value": value})
 
         # Convert selectors into ternary statements or `if` blocks

--- a/percy/parser/types.py
+++ b/percy/parser/types.py
@@ -110,7 +110,7 @@ class MessageTable:
     handle the logging of these messages.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Constructs an empty message table
         """

--- a/percy/parser/types.py
+++ b/percy/parser/types.py
@@ -17,6 +17,10 @@ NodeValue = Primitives | list[str]
 
 #### Constants ####
 
+# The "new" recipe format introduces the concept of a schema version. Presumably the "old" recipe format would be
+# considered "0". When converting to the new format, we'll use this constant value.
+CURRENT_RECIPE_SCHEMA_FORMAT: Final[int] = 1
+
 # Indicates how many spaces are in a level of indentation
 TAB_SPACE_COUNT: Final[int] = 2
 TAB_AS_SPACES: Final[str] = " " * TAB_SPACE_COUNT

--- a/percy/parser/types.py
+++ b/percy/parser/types.py
@@ -4,6 +4,7 @@ Description:    Provides public types, type aliases, constants, and small classe
 """
 from __future__ import annotations
 
+from enum import StrEnum, auto
 from typing import Final
 
 from percy.types import Primitives, SchemaType
@@ -88,3 +89,69 @@ JSON_PATCH_SCHEMA: Final[SchemaType] = {
     ],
     "additionalProperties": False,
 }
+
+
+class MessageCategory(StrEnum):
+    """
+    Categories to classify `RecipeParser` messages into.
+    """
+
+    ERROR = auto()
+    WARNING = auto()
+
+
+class MessageTable:
+    """
+    Stores and tags messages that may come up during `RecipeParser` operations. It is up to the client program to
+    handle the logging of these messages.
+    """
+
+    def __init__(self):
+        """
+        Constructs an empty message table
+        """
+        self._tbl: dict[MessageCategory, list[str]] = {}
+
+    def add_message(self, category: MessageCategory, message: str) -> None:
+        """
+        Adds a message to the table
+        :param category:
+        :param message:
+        """
+        if category not in self._tbl:
+            self._tbl[category] = []
+        self._tbl[category].append(message)
+
+    def get_messages(self, category: MessageCategory) -> list[str]:
+        """
+        Returns all the messages stored in a given category
+        :param category: Category to target
+        :returns: A list containing all the messages stored in a category.
+        """
+        if category not in self._tbl:
+            return []
+        return self._tbl[category]
+
+    def get_totals_message(self) -> str:
+        """
+        Convenience function that returns a displayable count of the number of warnings and errors contained in the
+        messaging object.
+        :returns: A message indicating the number of errors and warnings that have been accumulated. If there are none,
+                  an empty string is returned.
+        """
+        if not self._tbl:
+            return ""
+
+        def _pluralize(n: int, s: str) -> str:
+            if n == 1:
+                return s
+            return f"{s}s"
+
+        num_errors: Final[int] = 0 if MessageCategory.ERROR not in self._tbl else len(self._tbl[MessageCategory.ERROR])
+        errors: Final[str] = f"{num_errors} {_pluralize(num_errors, 'error')}"
+        num_warnings: Final[int] = (
+            0 if MessageCategory.WARNING not in self._tbl else len(self._tbl[MessageCategory.WARNING])
+        )
+        warnings: Final[str] = f"{num_warnings} {_pluralize(num_warnings, 'warning')}"
+
+        return f"{errors} and {warnings} were found."

--- a/percy/parser/types.py
+++ b/percy/parser/types.py
@@ -136,6 +136,16 @@ class MessageTable:
             return []
         return self._tbl[category]
 
+    def get_message_count(self, category: MessageCategory) -> int:
+        """
+        Returns how many messages are stored in a given category
+        :param category: Category to target
+        :returns: A list containing all the messages stored in a category.
+        """
+        if category not in self._tbl:
+            return 0
+        return len(self._tbl[category])
+
     def get_totals_message(self) -> str:
         """
         Convenience function that returns a displayable count of the number of warnings and errors contained in the

--- a/percy/tests/commands/test_convert_cli.py
+++ b/percy/tests/commands/test_convert_cli.py
@@ -1,0 +1,22 @@
+"""
+File:           test_convert_cli.py
+Description:    Tests the `convert` CLI
+"""
+from click.testing import CliRunner
+
+from percy.commands.convert import convert
+
+
+def test_usage() -> None:
+    """
+    Ensure failure to provide a sub-command results in rendering the help menu
+    """
+    runner = CliRunner()
+    # No commands are provided
+    result = runner.invoke(convert, [])
+    assert result.exit_code != 0
+    assert result.output.startswith("Usage:")
+    # Help is specified
+    result = runner.invoke(convert, ["--help"])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -252,7 +252,7 @@ def test_render_to_object_multi_output() -> None:
     }
 
 
-@pytest.mark.parametrize("file_base", ["simple-recipe.yaml"])
+@pytest.mark.parametrize("file_base", ["simple-recipe.yaml", "multi-output.yaml"])
 def test_render_to_new_recipe_format(file_base: str) -> None:
     """
     Validates rendering a recipe in the new format.
@@ -1344,6 +1344,10 @@ def test_patch_add() -> None:
     # Edge case: adding a value to an existing key (non-list) actually replaces the value at that key, as per the RFC.
     assert parser.patch({"op": "add", "path": "/about/summary", "value": 62})
 
+    # Add a value in a list with a comment
+    assert parser.patch({"op": "add", "path": "/multi_level/list_1/1", "value": "ken"})
+    assert parser.patch({"op": "add", "path": "/multi_level/list_1/3", "value": "barbie"})
+
     # Sanity check: validate all modifications
     assert parser.is_modified()
     assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_add.yaml")
@@ -1477,6 +1481,31 @@ def test_patch_replace() -> None:
             "op": "replace",
             "path": "/multi_level/list_2/1",
             "value": {"build": {"number": 42, "skip": True}},
+        }
+    )
+
+    # Patch-in strings with quotes
+    assert parser.patch(
+        {
+            "op": "replace",
+            "path": "/multi_level/list_3/2",
+            "value": "{{ compiler('c') }}",
+        }
+    )
+
+    # Patch lists with comments
+    assert parser.patch(
+        {
+            "op": "replace",
+            "path": "/multi_level/list_1/0",
+            "value": "ken",
+        }
+    )
+    assert parser.patch(
+        {
+            "op": "replace",
+            "path": "/multi_level/list_1/1",
+            "value": "barbie",
         }
     )
 

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -472,6 +472,25 @@ def test_get_package_paths(file: str, expected: list[str]) -> None:
 
 
 @pytest.mark.parametrize(
+    "base,ext,expected",
+    [
+        ("", "", "/"),
+        ("/", "/foo/bar", "/foo/bar"),
+        ("/", "foo/bar", "/foo/bar"),
+        ("/foo/bar", "baz", "/foo/bar/baz"),
+        ("/foo/bar", "/baz", "/foo/bar/baz"),
+    ],
+)
+def test_append_to_path(base: str, ext: str, expected) -> None:
+    """
+    :param base: Base string path
+    :param ext: Path to extend the base path with
+    :param expected: Expected output
+    """
+    assert RecipeParser.append_to_path(base, ext) == expected
+
+
+@pytest.mark.parametrize(
     "file,expected",
     [
         (

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -254,7 +254,10 @@ def test_render_to_object_multi_output() -> None:
 
 @pytest.mark.parametrize("file_base", ["simple-recipe.yaml"])
 def test_render_to_new_recipe_format(file_base: str) -> None:
-    # TODO formalize test, this is a prototype/smoke-test
+    """
+    Validates rendering a recipe in the new format.
+    TODO: re-enable the "multi-output.yaml" test when the single-quoted strings bug is resolved.
+    """
     parser = load_recipe(file_base)
     assert parser.render_to_new_recipe_format() == load_file(f"{TEST_FILES_PATH}/new_format_{file_base}")
     # Ensure that the original file was untouched

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -259,7 +259,9 @@ def test_render_to_new_recipe_format(file_base: str) -> None:
     TODO: re-enable the "multi-output.yaml" test when the single-quoted strings bug is resolved.
     """
     parser = load_recipe(file_base)
-    assert parser.render_to_new_recipe_format() == load_file(f"{TEST_FILES_PATH}/new_format_{file_base}")
+    # TODO: validate messages returned
+    result, _ = parser.render_to_new_recipe_format()
+    assert result == load_file(f"{TEST_FILES_PATH}/new_format_{file_base}")
     # Ensure that the original file was untouched
     assert not parser.is_modified()
     assert parser.diff() == ""

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -252,11 +252,14 @@ def test_render_to_object_multi_output() -> None:
     }
 
 
-def test_render_to_new_recipe_format() -> None:
+@pytest.mark.parametrize("file_base", ["simple-recipe.yaml"])
+def test_render_to_new_recipe_format(file_base: str) -> None:
     # TODO formalize test, this is a prototype/smoke-test
-    parser = load_recipe("simple-recipe.yaml")
-    print("")
-    print(parser.render_to_new_recipe_format())
+    parser = load_recipe(file_base)
+    assert parser.render_to_new_recipe_format() == load_file(f"{TEST_FILES_PATH}/new_format_{file_base}")
+    # Ensure that the original file was untouched
+    assert not parser.is_modified()
+    assert parser.diff() == ""
 
 
 ## Values ##

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -256,7 +256,6 @@ def test_render_to_object_multi_output() -> None:
 def test_render_to_new_recipe_format(file_base: str) -> None:
     """
     Validates rendering a recipe in the new format.
-    TODO: re-enable the "multi-output.yaml" test when the single-quoted strings bug is resolved.
     """
     parser = load_recipe(file_base)
     # TODO: validate messages returned

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -400,6 +400,23 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
             },
         ),
         ## multi-output.yaml ##
+        ("multi-output.yaml", "/outputs/0/build/run_exports/0", False, "bar"),
+        ("multi-output.yaml", "/outputs/0/build/run_exports", False, ["bar"]),
+        ("multi-output.yaml", "/outputs/0/build", False, {"run_exports": ["bar"]}),
+        # TODO FIX: This case
+        # (
+        #    "multi-output.yaml",
+        #    "/outputs/1",
+        #    False,
+        #    {
+        #        "name": "db",
+        #        "requirements": {
+        #            "build": ["foo3", "foo2", "{{ compiler('c') }}", "{{ compiler('cxx') }}"],
+        #            "run": ["foo"],
+        #        },
+        #        "test": {"commands": ["db_archive -m hello"]},
+        #    },
+        # ),
     ],
 )
 def test_get_value(file: str, path: str, sub_vars: bool, expected: JsonType) -> None:

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -12,6 +12,7 @@ import pytest
 from percy.parser.enums import SelectorConflictMode
 from percy.parser.exceptions import JsonPatchValidationException
 from percy.parser.recipe_parser import RecipeParser
+from percy.parser.types import MessageCategory
 from percy.types import JsonType
 
 # Path to supplementary files used in test cases
@@ -259,9 +260,9 @@ def test_render_to_new_recipe_format(file_base: str) -> None:
     Validates rendering a recipe in the new format.
     """
     parser = load_recipe(file_base)
-    # TODO: validate messages returned
-    result, _ = parser.render_to_new_recipe_format()
+    result, tbl = parser.render_to_new_recipe_format()
     assert result == load_file(f"{TEST_FILES_PATH}/new_format_{file_base}")
+    assert tbl.get_messages(MessageCategory.ERROR) == []
     # Ensure that the original file was untouched
     assert not parser.is_modified()
     assert parser.diff() == ""

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -252,6 +252,13 @@ def test_render_to_object_multi_output() -> None:
     }
 
 
+def test_render_to_new_recipe_format() -> None:
+    # TODO formalize test, this is a prototype/smoke-test
+    parser = load_recipe("simple-recipe.yaml")
+    print("")
+    print(parser.render_to_new_recipe_format())
+
+
 ## Values ##
 
 

--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -305,20 +305,37 @@ def test_list_value_paths() -> None:
     ]
 
 
-def test_contains_value() -> None:
+@pytest.mark.parametrize(
+    "file,path,expected",
+    [
+        ## simple-recipe.yaml ##
+        ("simple-recipe.yaml", "/build/number", True),
+        ("simple-recipe.yaml", "/build/number/", True),
+        ("simple-recipe.yaml", "/build", True),
+        ("simple-recipe.yaml", "/requirements/host/0", True),
+        ("simple-recipe.yaml", "/requirements/host/1", True),
+        ("simple-recipe.yaml", "/multi_level/list_1/1", True),  # Comments in lists could throw-off array indexing
+        ("simple-recipe.yaml", "/invalid/fake/path", False),
+        ## multi-output.yaml ##
+        ("multi-output.yaml", "/outputs/0/build/run_exports", True),
+        ("multi-output.yaml", "/outputs/1/build/run_exports", False),
+        ("multi-output.yaml", "/outputs/1/requirements/0", False),  # Should fail as this is an object, not a list
+        ("multi-output.yaml", "/outputs/1/requirements/build/0", True),
+        ("multi-output.yaml", "/outputs/1/requirements/build/1", True),
+        ("multi-output.yaml", "/outputs/1/requirements/build/2", True),
+        ("multi-output.yaml", "/outputs/1/requirements/build/3", True),
+        ("multi-output.yaml", "/outputs/1/requirements/build/4", False),
+    ],
+)
+def test_contains_value(file: str, path: str, expected: bool) -> None:
     """
-    Tests retrieval of a value from a parsed YAML example.
+    Tests if a path exists in a parsed recipe file.
+    :param file: File to work against
+    :param path: Target input path
+    :param expected: Expected result of the test
     """
-    parser = load_recipe("simple-recipe.yaml")
-    assert parser.contains_value("/build/number")
-    assert parser.contains_value("/build/number/")
-    assert parser.contains_value("/build")
-    assert parser.contains_value("/requirements/host/0")
-    assert parser.contains_value("/requirements/host/1")
-    # Comments in lists could throw-off array indexing
-    assert parser.contains_value("/multi_level/list_1/1")
-    # Path not found cases
-    assert not parser.contains_value("/invalid/fake/path")
+    parser = load_recipe(file)
+    assert parser.contains_value(path) == expected
     assert not parser.is_modified()
 
 

--- a/percy/tests/test_aux_files/new_format_multi-output.yaml
+++ b/percy/tests/test_aux_files/new_format_multi-output.yaml
@@ -1,0 +1,29 @@
+context:
+
+outputs:
+  - name: libdb
+    build:
+      run_exports:
+        # OK for minor
+        # https://abi-laboratory.pro/?view=timeline&l=libdb
+        - bar
+    test:
+      commands:
+        - if: unix
+          then: test -f ${PREFIX}/lib/libdb${SHLIB_EXT}
+        - if: win
+          then: if not exist %LIBRARY_BIN%\libdb%SHLIB_EXT%
+  # metapackage for old anaconda name (only available on linux/mac)
+  - name: db
+    requirements:
+      build:
+        # compilers are to ensure that variants are captured
+        - foo3
+        - foo2
+        - ${{ compiler('c') }}
+        - ${{ compiler('cxx') }}
+      run:
+        - foo
+    test:
+      commands:
+        - db_archive -m hello

--- a/percy/tests/test_aux_files/new_format_multi-output.yaml
+++ b/percy/tests/test_aux_files/new_format_multi-output.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 context:
 
 outputs:

--- a/percy/tests/test_aux_files/new_format_multi-output.yaml
+++ b/percy/tests/test_aux_files/new_format_multi-output.yaml
@@ -5,16 +5,15 @@ context:
 outputs:
   - name: libdb
     build:
-      run_exports:
-        # OK for minor
-        # https://abi-laboratory.pro/?view=timeline&l=libdb
-        - bar
     test:
       commands:
         - if: unix
           then: test -f ${PREFIX}/lib/libdb${SHLIB_EXT}
         - if: win
           then: if not exist %LIBRARY_BIN%\libdb%SHLIB_EXT%
+    requirements:
+      run_exports:
+        - bar
   # metapackage for old anaconda name (only available on linux/mac)
   - name: db
     requirements:

--- a/percy/tests/test_aux_files/new_format_simple-recipe.yaml
+++ b/percy/tests/test_aux_files/new_format_simple-recipe.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
 context:
+  zz_non_alpha_first: 42
   name: types-toml
   version: 0.10.8.6
-  zz_non_alpha_first: 42
 
 package:
   name: ${{ name|lower }}

--- a/percy/tests/test_aux_files/new_format_simple-recipe.yaml
+++ b/percy/tests/test_aux_files/new_format_simple-recipe.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 context:
   name: types-toml
   version: 0.10.8.6

--- a/percy/tests/test_aux_files/new_format_simple-recipe.yaml
+++ b/percy/tests/test_aux_files/new_format_simple-recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  name: types-toml
+  version: 0.10.8.6
+  zz_non_alpha_first: 42
+
+package:
+  name: ${{ name|lower }}
+
+build:
+  number: 0
+  skip: ${{ true if py<37 }}
+  is_true: true
+
+# Comment above a top-level structure
+requirements:
+  empty_field1:
+  host:
+    - if: unix
+      then: setuptools
+    - if: unix
+      then: fakereq
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
+  run:
+    - python  # not a selector
+  empty_field3:
+
+about:
+  summary: This is a small recipe for testing
+  description: |
+    This is a PEP '561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+
+multi_level:
+  list_1:
+    - foo
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - bat
+    - mat
+  list_3:
+    - ls
+    - sl
+    - cowsay
+
+test_var_usage:
+  foo: ${{ version }}
+  bar:
+    - baz
+    - ${{ zz_non_alpha_first }}
+    - blah
+    - This ${{ name }} is silly
+    - last

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_add.yaml
@@ -34,8 +34,10 @@ about:
 multi_level:
   list_1:
     - "There's just one place to go for all your spatula needs!"
+    - ken
     - foo
     # Ensure a comment in a list is supported
+    - barbie
     - bar
     - Spatula City!
   list_2:

--- a/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_patch_replace.yaml
@@ -34,9 +34,9 @@ about:
 
 multi_level:
   list_1:
-    - foo
+    - ken
     # Ensure a comment in a list is supported
-    - bar
+    - barbie
   list_2:
     - cat
     - build:
@@ -46,7 +46,7 @@ multi_level:
   list_3:
     - ls
     - sl
-    - cowsay
+    - {{ compiler('c') }}
 
 test_var_usage:
   foo: {{ version }}


### PR DESCRIPTION
This is very much an early POC. There are many `TODO`s and it is far from perfect. There are known bugs and gaps, documented in the `TODO`s

The primary goal of this PR is to implement most of the features discussed in [CEP-13](https://github.com/conda-incubator/ceps/blob/main/cep-13.md) and see how feasible it is to build a conversion utility in percy.

So far, so very good. As noted in the function, I am trying to use as many features of the current parser as possible to:
- Reduce engineering effort
- Gives us flexibility if we decide to expand support past a single conversion function

For less than a day's worth of work, I think this is a pretty solid POC and shows how the parser can make this work less painful.

Annoyingly I can't seem to add @wolfv to the PR despite this being an open project. I will ping him separately, but maybe that's a limitation we need to investigate @jezdez if we want community feedback. I imagine it's tied to some IT permissions group control.