### PR TITLE
Starts work on comment preservation

### DIFF
--- a/percy/tests/parser/test_recipe_parser.py
+++ b/percy/tests/parser/test_recipe_parser.py
@@ -317,6 +317,7 @@ def test_render_to_object_multi_output() -> None:
     }
 
 
+# TODO: Finish `curl.yaml` test
 @pytest.mark.parametrize("file_base", ["simple-recipe.yaml", "multi-output.yaml", "huggingface_hub.yaml"])
 def test_render_to_new_recipe_format(file_base: str) -> None:
     """
@@ -962,6 +963,33 @@ def test_remove_selector() -> None:
 
     assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_remove_selector.yaml")
     assert parser.is_modified()
+
+
+## Comments ##
+
+
+def test_get_comments_table() -> None:
+    pass
+
+
+def test_add_comment() -> None:
+    pass
+
+
+def test_add_comment_raises() -> None:
+    """
+    Tests scenarios where `add_comment()` should raise an exception
+    """
+    parser = load_recipe("simple-recipe.yaml")
+
+    with pytest.raises(KeyError):
+        parser.add_comment("/package/path/to/fake/value", "A comment")
+    with pytest.raises(ValueError):
+        parser.add_comment("/build/number", "[unix]")
+    with pytest.raises(ValueError):
+        parser.add_comment("/build/number", "")
+    with pytest.raises(ValueError):
+        parser.add_comment("/build/number", "    ")
 
 
 ## Patch and Search ##

--- a/percy/tests/test_aux_files/curl.yaml
+++ b/percy/tests/test_aux_files/curl.yaml
@@ -1,0 +1,135 @@
+{% set version = "8.4.0" %}
+
+package:
+  name: curl_split_recipe
+  version: {{ version }}
+
+source:
+  url: https://curl.se/download/curl-{{ version }}.tar.bz2
+  sha256: e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - libtool        # [unix]
+    - {{ compiler('c') }}
+    - make           # [unix]
+    # perl is required to run the tests on UNIX.
+    - perl           # [unix]
+    - pkg-config     # [unix]
+  host:
+    - krb5        1.20.1
+    - libnghttp2  1.57.0  # [unix]
+    - libssh2     1.10.0
+    - openssl     {{ openssl }}  # [unix]
+    - zlib        {{ zlib }}
+
+outputs:
+  - name: libcurl
+    requirements:
+      build:
+        - {{ compiler('c') }}
+      host:
+        - krb5        1.20.1
+        - libnghttp2  1.57.0  # [unix]
+        - libssh2     1.10.0
+        - openssl     {{ openssl }}  # [unix]
+        - zlib        {{ zlib }}
+      run:
+        - libnghttp2  >=1.57.0  # [unix]
+        - libssh2     >=1.10.0
+        - openssl  # exact pin handled through openssl run_exports
+    build:
+      run_exports:
+        - {{ pin_subpackage('libcurl') }}
+      ignore_run_exports:  # [win]
+        - krb5             # [win]
+    files:
+      - include/curl             # [unix]
+      - lib/libcurl.so*          # [linux]
+      - lib/libcurl*.dylib       # [osx]
+      - lib/pkgconfig/libcurl*   # [unix]
+      - bin/curl-config          # [unix]
+      - Library/bin/libcurl.dll  # [win]
+      - Library/include/curl     # [win]
+      - Library/lib/libcurl.lib  # [win]
+      - Library/lib/libcurl.exp  # [win]
+    test:
+      commands:
+        - curl-config --features       # [not win]
+        - curl-config --protocols      # [not win]
+        - test -f ${PREFIX}/lib/libcurl${SHLIB_EXT}  # [not win]
+        - test ! -f ${PREFIX}/lib/libcurl.a          # [not win]
+        - if exist %LIBRARY_BIN%\curl.exe exit 1     # [win]
+        - if exist %LIBRARY_LIB%\libcurl_a.lib exit 1     # [win]
+        - if not exist %LIBRARY_BIN%\libcurl.dll exit 1   # [win]
+
+  - name: libcurl-static
+    requirements:
+      build:
+        - {{ compiler('c') }}
+      host:
+        - krb5     1.20.1
+        - libssh2  1.10.0
+        - openssl  {{ openssl }}  # [unix]
+        - zlib     {{ zlib }}
+        - {{ pin_subpackage('libcurl', exact=True) }}
+      run:
+        - {{ pin_subpackage('libcurl', exact=True) }}
+    files:
+      - lib/libcurl.a*             # [unix]
+      - Library/lib/libcurl_a.lib  # [win]
+    test:
+      commands:
+        - test -f $PREFIX/lib/libcurl.a                    # [not win]
+        - if not exist %LIBRARY_LIB%\libcurl_a.lib exit 1  # [win]
+
+  - name: curl
+    files:
+      - bin/curl                # [unix]
+      - Library/bin/curl.exe*   # [win]
+    build:
+      ignore_run_exports:
+        # Ignoring the run export since we use openssl in the host section
+        # as a means to produce the right variants only. We don't need the dependency
+        # since it's already on libcurl.
+        - openssl
+    requirements:
+      build:
+        - {{ compiler('c') }}
+      host:
+        - openssl {{ openssl }} # Only required to produce all openssl variants.
+        - {{ pin_subpackage('libcurl', exact=True) }}
+      run:
+        - {{ pin_subpackage('libcurl', exact=True) }}
+
+    test:
+      commands:
+        # curl help commands on Windows have non-zero status codes.  Need other test.
+        - curl --help
+        # Try downloading something from https to make sure the certs are used correctly.
+        - curl https://raw.githubusercontent.com/conda-forge/curl-feedstock/master/LICENSE.txt
+        - if not exist %LIBRARY_BIN%\curl.exe exit 1  # [win]
+
+about:
+  home: https://curl.se/
+  license: curl
+  license_url: https://curl.se/docs/copyright.html
+  license_family: MIT
+  summary: tool and library for transferring data with URL syntax
+
+  description: |
+    Curl is an open source command line tool and library for transferring data
+    with URL syntax. It is used in command lines or scripts to transfer data.
+  doc_url: https://curl.se/docs/
+  dev_url: https://github.com/curl/curl
+
+extra:
+  recipe-maintainers:
+    - msarahan
+    - jakirkham
+    - ocefpaf
+    - mingwandroid
+    - xylar

--- a/percy/tests/test_aux_files/new_format_curl.yaml
+++ b/percy/tests/test_aux_files/new_format_curl.yaml
@@ -1,0 +1,169 @@
+schema_version: 1
+
+context:
+  version: 8.4.0
+
+package:
+  name: curl_split_recipe
+  version: ${{ version }}
+
+source:
+  url: https://curl.se/download/curl-${{ version }}.tar.bz2
+  sha256: e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - if: unix
+      then: libtool
+    - ${{ compiler('c') }}
+    - if: unix
+      then: make
+    # perl is required to run the tests on UNIX.
+    - if: unix
+      then: perl
+    - if: unix
+      then: pkg-config
+  host:
+    - krb5        1.20.1
+    - if: unix
+      then: libnghttp2  1.57.0
+    - libssh2     1.10.0
+    - if: unix
+      then: openssl     ${{ openssl }}
+    - zlib        ${{ zlib }}
+
+outputs:
+  - name: libcurl
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - krb5        1.20.1
+        - if: unix
+          then: libnghttp2  1.57.0
+        - libssh2     1.10.0
+        - if: unix
+          then: openssl     ${{ openssl }}
+        - zlib        ${{ zlib }}
+      run:
+        - if: unix
+          then: libnghttp2  >=1.57.0
+        - libssh2     >=1.10.0
+        - openssl  # exact pin handled through openssl run_exports
+    build:
+      run_exports:
+        - ${{ pin_subpackage('libcurl') }}
+      ignore_run_exports:  # [win]
+        - if: win
+          then: krb5
+    files:
+      - if: unix
+        then: include/curl
+      - if: linux
+        then: lib/libcurl.so*
+      - if: osx
+        then: lib/libcurl*.dylib
+      - if: unix
+        then: lib/pkgconfig/libcurl*
+      - if: unix
+        then: bin/curl-config
+      - if: win
+        then: Library/bin/libcurl.dll
+      - if: win
+        then: Library/include/curl
+      - if: win
+        then: Library/lib/libcurl.lib
+      - if: win
+        then: Library/lib/libcurl.exp
+    test:
+      commands:
+        - if: not win
+          then: curl-config --features
+        - if: not win
+          then: curl-config --protocols
+        - if: not win
+          then: test -f ${PREFIX}/lib/libcurl${SHLIB_EXT}
+        - if: not win
+          then: test ! -f ${PREFIX}/lib/libcurl.a
+        - if: win
+          then: if exist %LIBRARY_BIN%\curl.exe exit 1
+        - if: win
+          then: if exist %LIBRARY_LIB%\libcurl_a.lib exit 1
+        - if: win
+          then: if not exist %LIBRARY_BIN%\libcurl.dll exit 1
+
+  - name: libcurl-static
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - krb5     1.20.1
+        - libssh2  1.10.0
+        - if: win
+          then: openssl  ${{ openssl }}
+        - zlib     ${{ zlib }}
+        - ${{ pin_subpackage('libcurl', exact=True) }}
+      run:
+        - ${{ pin_subpackage('libcurl', exact=True) }}
+    files:
+      - if: unix
+        then: lib/libcurl.a*
+      - if: win
+        then: Library/lib/libcurl_a.lib
+    test:
+      commands:
+        - if: not win
+          then: test -f $PREFIX/lib/libcurl.a
+        - if: win
+          then: if not exist %LIBRARY_LIB%\libcurl_a.lib exit 1
+
+  - name: curl
+    files:
+      - if: unix
+        then: bin/curl
+      - if: win
+        then: Library/bin/curl.exe*
+    build:
+      ignore_run_exports:
+        # Ignoring the run export since we use openssl in the host section
+        # as a means to produce the right variants only. We don't need the dependency
+        # since it's already on libcurl.
+        - openssl
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - openssl ${{ openssl }}  # Only required to produce all openssl variants.
+        - ${{ pin_subpackage('libcurl', exact=True) }}
+      run:
+        - ${{ pin_subpackage('libcurl', exact=True) }}
+    test:
+      commands:
+        # curl help commands on Windows have non-zero status codes.  Need other test.
+        - curl --help
+        # Try downloading something from https to make sure the certs are used correctly.
+        - curl https://raw.githubusercontent.com/conda-forge/curl-feedstock/master/LICENSE.txt
+        - if: win
+          then: if not exist %LIBRARY_BIN%\curl.exe exit 1
+
+about:
+  license: curl
+  license_url: https://curl.se/docs/copyright.html
+  summary: tool and library for transferring data with URL syntax
+  description: |
+    Curl is an open source command line tool and library for transferring data
+    with URL syntax. It is used in command lines or scripts to transfer data.
+  homepage: https://curl.se/
+  repository: https://github.com/curl/curl
+  documentation: https://curl.se/docs/
+
+extra:
+  recipe-maintainers:
+    - msarahan
+    - jakirkham
+    - ocefpaf
+    - mingwandroid
+    - xylar

--- a/percy/tests/test_aux_files/simple-recipe_test_add_comment.yaml
+++ b/percy/tests/test_aux_files/simple-recipe_test_add_comment.yaml
@@ -1,0 +1,53 @@
+{% set zz_non_alpha_first = 42 %}
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}  # [unix] Come on Jeffery
+
+build:
+  number: 0  # you can do it!
+  skip: true  # [py<37]
+  is_true: true
+
+# Comment above a top-level structure
+requirements:
+  empty_field1:  # Pave the way!
+  host:
+    - setuptools  # [unix]
+    - fakereq  # [unix] selector with comment
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
+  run:
+    - python  # not a selector
+  empty_field3:
+
+about:
+  summary: This is a small recipe for testing
+  description: |
+    This is a PEP '561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+
+multi_level:
+  list_1:  # Put your back into it!
+    - foo
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - bat  # Tell us why
+    - mat  # Show us how
+  list_3:
+    - ls  # Look at where you came from
+    - sl
+    - cowsay
+
+test_var_usage:
+  foo: {{ version }}  # Look at you now!
+  bar:
+    - baz
+    - {{ zz_non_alpha_first }}
+    - blah
+    - This {{ name }} is silly
+    - last


### PR DESCRIPTION
This project has had a few false starts and I'm not 100% happy with the current state. Trying to preserve non-selector comments while upgrading recipes is a bit of a pain.

This approach isn't great, but it might move us in the right direction. At the very least it might be a "good enough" solution for some time.

This PR also introduces the `curl.yaml` parser conversion test. This test is incomplete and broken. IF we can eventually perform a perfect or near-perfect conversion of `curl.yaml`, that'll be a good signal that we can handle some pretty complex recipes.

tl;dr This PR contains some experimental work. In an effort to reduce a future PR from getting very big, I'm introducing this work now.