### PR TITLE
First pass at converting `test` -> `tests` sections, some `outputs` conversion work

### DIFF
--- a/percy/parser/_types.py
+++ b/percy/parser/_types.py
@@ -39,6 +39,15 @@ TOP_LEVEL_KEY_SORT_ORDER: Final[dict[str, int]] = {
     "extra": 10,
 }
 
+# Canonical sort order for the new "v1" recipe format's `tests` block
+V1_TEST_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
+    "script": 0,
+    "requirements": 1,
+    "files": 2,
+    "python": 3,
+    "downstream": 4,
+}
+
 #### Private Classes (Not to be used external to the `parser` module) ####
 
 # NOTE: The classes put in this file should be structures (NamedTuples) and very small support classes that don't make

--- a/percy/parser/_types.py
+++ b/percy/parser/_types.py
@@ -34,8 +34,9 @@ TOP_LEVEL_KEY_SORT_ORDER: Final[dict[str, int]] = {
     "requirements": 5,
     "outputs": 6,
     "test": 7,
-    "about": 8,
-    "extra": 9,
+    "tests": 8,  # Used in the new recipe format
+    "about": 9,
+    "extra": 10,
 }
 
 #### Private Classes (Not to be used external to the `parser` module) ####

--- a/percy/parser/recipe_parser.py
+++ b/percy/parser/recipe_parser.py
@@ -899,15 +899,12 @@ class RecipeParser:
 
         # TODO: Comment tracking may need improvement. The "correct way" of tracking comments with patch changes is a
         #       fairly big engineering effort and refactor.
-        # Attempt to re-introduce comments that may have been removed with patch operations. This process is far
-        # from perfect, so log the comments we couldn't relocate.
+        # Alert the user which comments have been dropped.
         new_comments: Final[dict[str, str]] = new_recipe.get_comments_table()
         diff_comments: Final[dict[str, str]] = {k: v for k, v in old_comments.items() if k not in new_comments}
         for path, comment in diff_comments.items():
             if not new_recipe.contains_value(path):
                 msg_tbl.add_message(MessageCategory.WARNING, f"Could not relocate comment: {comment}")
-                continue
-            new_recipe.add_comment(path, comment)
 
         # TODO Complete: move operations may result in empty fields we can eliminate. This may require changes to
         #                `contains_value()`

--- a/percy/tests/test_aux_files/new_format_huggingface_hub.yaml
+++ b/percy/tests/test_aux_files/new_format_huggingface_hub.yaml
@@ -41,15 +41,17 @@ requirements:
     - fastcore >=1.3.27
     - InquirerPy ==0.3.4
 
-test:
-  imports:
-    - huggingface_hub
-    - huggingface_hub.commands
-  requires:
-    - pip
-  commands:
-    - pip check
+tests:
+  script:
     - huggingface-cli --help
+  requirements:
+    run:
+      - pip
+  python:
+    pip-check: true
+    imports:
+      - huggingface_hub
+      - huggingface_hub.commands
 
 about:
   summary: Client library to download and publish models, datasets and other repos on the huggingface.co hub

--- a/percy/tests/test_aux_files/new_format_multi-output.yaml
+++ b/percy/tests/test_aux_files/new_format_multi-output.yaml
@@ -5,12 +5,14 @@ context:
 outputs:
   - name: libdb
     build:
-    test:
-      commands:
+    tests:
+      script:
         - if: unix
           then: test -f ${PREFIX}/lib/libdb${SHLIB_EXT}
         - if: win
           then: if not exist %LIBRARY_BIN%\libdb%SHLIB_EXT%
+      python:
+        pip-check: false
     requirements:
       run_exports:
         - bar
@@ -25,6 +27,8 @@ outputs:
         - ${{ compiler('cxx') }}
       run:
         - foo
-    test:
-      commands:
+    tests:
+      script:
         - db_archive -m hello
+      python:
+        pip-check: false

--- a/percy/tests/test_aux_files/new_format_multi-output.yaml
+++ b/percy/tests/test_aux_files/new_format_multi-output.yaml
@@ -3,8 +3,12 @@ schema_version: 1
 context:
 
 outputs:
-  - name: libdb
+  - package:
+      name: libdb
     build:
+    requirements:
+      run_exports:
+        - bar
     tests:
       script:
         - if: unix
@@ -13,11 +17,9 @@ outputs:
           then: if not exist %LIBRARY_BIN%\libdb%SHLIB_EXT%
       python:
         pip-check: false
-    requirements:
-      run_exports:
-        - bar
   # metapackage for old anaconda name (only available on linux/mac)
-  - name: db
+  - package:
+      name: db
     requirements:
       build:
         # compilers are to ensure that variants are captured


### PR DESCRIPTION
![old_to_new_recipe_tests_mapping_diagram](https://github.com/anaconda-distribution/percy/assets/2274413/7638b8c1-f2fe-46dc-91dd-31e44cd327a1)
See the badly-hand-drawn diagram above for a rough outline of what is being done ^

This is the first-pass at converting the old `test` recipe section to the new `tests` recipe section. All `test` sections should be converted, regardless if the recipe produces single or multiple outputs.

Most keys map directly to newer counter parts. If a `pip check` command is listed under `commands`, it is upgraded to the new `tests/python/pip-check` flag. If it not found, the flag is set to `false`.

For now, only exact matches for `- pip check` are converted, with no special logic for handling selectors. This should cover the vast majority of recipes (at least from `AnacondaRecipes`).

The top-level keys found in the `tests` section are then canonically sorted, based on the ordering found in [CEP-14](https://github.com/conda-incubator/ceps/blob/main/cep-14.md#command-test-element).

Unit tests have been modified as needed.

EDIT: I was working on some of the `outputs` conversion work and it looked pretty straight forward, so I've added some of that into this PR.