### PR TITLE
Skip ctng-compiler-activation-feedstock because it is superseeded by gcc_activation-toolchain

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -30,5 +30,5 @@ runs:
         source $CONDA/etc/profile.d/conda.sh
         conda init bash
         sed -i 's/- python >=3.*$/- python ${{ inputs.python-version }}.*/' environment.yaml
-        conda env create -f environment.yaml --name percy --force
+        conda env create -f environment.yaml --name percy
         conda run --name percy pip install .

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -320,13 +320,13 @@ class Aggregate:
                 continue
             if feedstock_name.startswith("ctng-compilers-"):
                 logging.warning(
-                    "Skipping feedstock %s now replaced by binutils-feedstock and gcc_toolchain-toolchain",
+                    "Skipping feedstock %s now replaced by binutils-feedstock and gcc_toolchain-feedstock",
                     feedstock_name,
                 )
                 continue
             if feedstock_name.startswith("ctng-compiler-activation-"):
                 logging.warning(
-                    "Skipping feedstock %s now replaced by gcc_activation-toolchain",
+                    "Skipping feedstock %s now replaced by gcc_activation-feedstock",
                     feedstock_name,
                 )
                 continue

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -324,6 +324,12 @@ class Aggregate:
                     feedstock_name,
                 )
                 continue
+            if feedstock_name.startswith("ctng-compiler-activation-"):
+                logging.warning(
+                    "Skipping feedstock %s now replaced by gcc_activation-toolchain",
+                    feedstock_name,
+                )
+                continue
             if "_cos6_" in feedstock_name or "_cos7_" in feedstock_name or "_amzn2_" in feedstock_name:
                 logging.warning("Skipping cdt %s", feedstock_name)
                 continue

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -330,6 +330,24 @@ class Aggregate:
                     feedstock_name,
                 )
                 continue
+            if feedstock_name.startswith("llvm-compilers-"):
+                logging.warning(
+                    "Skipping feedstock %s now replaced by llvmdev-feedstock",
+                    feedstock_name,
+                )
+                continue
+            if feedstock_name.startswith("clang-compilers-"):
+                logging.warning(
+                    "Skipping feedstock %s now replaced by clangdev-feedstock",
+                    feedstock_name,
+                )
+                continue
+            if feedstock_name.startswith("clang-compiler-activation-"):
+                logging.warning(
+                    "Skipping feedstock %s now replaced by clangdev-feedstock",
+                    feedstock_name,
+                )
+                continue
             if "_cos6_" in feedstock_name or "_cos7_" in feedstock_name or "_amzn2_" in feedstock_name:
                 logging.warning("Skipping cdt %s", feedstock_name)
                 continue


### PR DESCRIPTION
We already skip rendering `ctng-compilers-feedstock`. We should also skip rendering it's companion `ctng-compiler-activation-feedstock`.